### PR TITLE
Wait condition improvements

### DIFF
--- a/Packages/Responsible/Runtime/Responsibly.WaitFor.cs
+++ b/Packages/Responsible/Runtime/Responsibly.WaitFor.cs
@@ -144,6 +144,20 @@ namespace Responsible
 				TimeSpan.FromSeconds(seconds),
 				new SourceContext(nameof(WaitForSeconds), memberName, sourceFilePath, sourceLineNumber));
 
+		/// <summary>
+		/// Wait for the given amount of WHOLE frames.
+		/// Note that zero frames means to wait until the next frame.
+		/// </summary>
+		[Pure]
+		public static ITestInstruction<Unit> WaitForFrames(
+			int frames,
+			[CallerMemberName] string memberName = "",
+			[CallerFilePath] string sourceFilePath = "",
+			[CallerLineNumber] int sourceLineNumber = 0)
+			=> new WaitForFramesInstruction(
+				frames,
+				new SourceContext(nameof(WaitForSeconds), memberName, sourceFilePath, sourceLineNumber));
+
 		[Pure]
 		public static ITestWaitCondition<T> WaitForLast<T>(
 			string description,

--- a/Packages/Responsible/Runtime/Responsibly.WaitFor.cs
+++ b/Packages/Responsible/Runtime/Responsibly.WaitFor.cs
@@ -136,7 +136,7 @@ namespace Responsible
 
 		[Pure]
 		public static ITestInstruction<Unit> WaitForSeconds(
-			int seconds,
+			double seconds,
 			[CallerMemberName] string memberName = "",
 			[CallerFilePath] string sourceFilePath = "",
 			[CallerLineNumber] int sourceLineNumber = 0)

--- a/Packages/Responsible/Runtime/Responsibly.WaitFor.cs
+++ b/Packages/Responsible/Runtime/Responsibly.WaitFor.cs
@@ -52,6 +52,10 @@ namespace Responsible
 				extraContext,
 				new SourceContext(nameof(WaitForCondition), memberName, sourceFilePath, sourceLineNumber));
 
+		/// <summary>
+		/// Constructs a wait condition that becomes true when the given constraint
+		/// is fulfilled on the object returned by <c>getObject</c>.
+		/// </summary>
 		[Pure]
 		public static ITestWaitCondition<T> WaitForConstraint<T>(
 			string objectDescription,
@@ -65,7 +69,6 @@ namespace Responsible
 				getObject,
 				constraint,
 				new SourceContext(nameof(WaitForConstraint), memberName, sourceFilePath, sourceLineNumber));
-
 
 		[Pure]
 		public static ITestWaitCondition<Unit> WaitForCoroutine(

--- a/Packages/Responsible/Runtime/Responsibly.WaitFor.cs
+++ b/Packages/Responsible/Runtime/Responsibly.WaitFor.cs
@@ -22,6 +22,41 @@ namespace Responsible
 	public static partial class Responsibly
 	{
 		[Pure]
+		public static ITestWaitCondition<TResult> WaitForConditionOn<TObject, TResult>(
+			string description,
+			Func<TObject> getObject,
+			Func<TObject, bool> condition,
+			Func<TObject, TResult> makeResult,
+			Action<StateStringBuilder> extraContext = null,
+			[CallerMemberName] string memberName = "",
+			[CallerFilePath] string sourceFilePath = "",
+			[CallerLineNumber] int sourceLineNumber = 0)
+			=> new PollingWaitCondition<TObject, TResult>(
+				description,
+				getObject,
+				condition,
+				makeResult,
+				extraContext,
+				new SourceContext(nameof(WaitForCondition), memberName, sourceFilePath, sourceLineNumber));
+
+		[Pure]
+		public static ITestWaitCondition<T> WaitForConditionOn<T>(
+			string description,
+			Func<T> getObject,
+			Func<T, bool> condition,
+			Action<StateStringBuilder> extraContext = null,
+			[CallerMemberName] string memberName = "",
+			[CallerFilePath] string sourceFilePath = "",
+			[CallerLineNumber] int sourceLineNumber = 0)
+			=> new PollingWaitCondition<T, T>(
+				description,
+				getObject,
+				condition,
+				_ => _,
+				extraContext,
+				new SourceContext(nameof(WaitForCondition), memberName, sourceFilePath, sourceLineNumber));
+
+		[Pure]
 		public static ITestWaitCondition<T> WaitForCondition<T>(
 			string description,
 			Func<bool> condition,
@@ -30,10 +65,11 @@ namespace Responsible
 			[CallerMemberName] string memberName = "",
 			[CallerFilePath] string sourceFilePath = "",
 			[CallerLineNumber] int sourceLineNumber = 0)
-			=> new PollingWaitCondition<T>(
+			=> new PollingWaitCondition<Unit, T>(
 				description,
-				condition,
-				makeResult,
+				() => Unit.Default,
+				_ => condition(),
+				_ => makeResult(),
 				extraContext,
 				new SourceContext(nameof(WaitForCondition), memberName, sourceFilePath, sourceLineNumber));
 
@@ -45,10 +81,11 @@ namespace Responsible
 			[CallerMemberName] string memberName = "",
 			[CallerFilePath] string sourceFilePath = "",
 			[CallerLineNumber] int sourceLineNumber = 0)
-			=> new PollingWaitCondition<Unit>(
+			=> new PollingWaitCondition<Unit, Unit>(
 				description,
-				condition,
 				() => Unit.Default,
+				_ => condition(),
+				_ => Unit.Default,
 				extraContext,
 				new SourceContext(nameof(WaitForCondition), memberName, sourceFilePath, sourceLineNumber));
 

--- a/Packages/Responsible/Runtime/TestInstructions/WaitForFramesInstruction.cs
+++ b/Packages/Responsible/Runtime/TestInstructions/WaitForFramesInstruction.cs
@@ -1,0 +1,32 @@
+using System;
+using Responsible.Context;
+using Responsible.State;
+using UniRx;
+
+namespace Responsible.TestInstructions
+{
+	internal class WaitForFramesInstruction : TestInstructionBase<Unit>
+	{
+		public WaitForFramesInstruction(int frames, SourceContext sourceContext)
+			: base(() => new State(frames, sourceContext))
+		{
+		}
+
+		private class State : TestOperationState<Unit>
+		{
+			private readonly int frames;
+
+			public State(int frames, SourceContext sourceContext)
+				: base(sourceContext)
+			{
+				this.frames = frames;
+			}
+
+			protected override IObservable<Unit> ExecuteInner(RunContext runContext)
+				=> Observable.TimerFrame(this.frames).AsUnitObservable();
+
+			public override void BuildDescription(StateStringBuilder builder) =>
+				builder.AddInstruction(this, $"WAIT FOR {this.frames} FRAME(S)");
+		}
+	}
+}

--- a/Packages/Responsible/Runtime/TestInstructions/WaitForFramesInstruction.cs.meta
+++ b/Packages/Responsible/Runtime/TestInstructions/WaitForFramesInstruction.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a2894f79cd064103905b476cdd68f1e2
+timeCreated: 1604156047

--- a/Packages/Responsible/Runtime/TestResponder.cs
+++ b/Packages/Responsible/Runtime/TestResponder.cs
@@ -17,7 +17,7 @@ namespace Responsible
 		[Pure]
 		public static ITestInstruction<TResult> ExpectWithinSeconds<TResult>(
 			this ITestResponder<TResult> responder,
-			int timeoutSeconds,
+			double timeoutSeconds,
 			[CallerMemberName] string memberName = "",
 			[CallerFilePath] string sourceFilePath = "",
 			[CallerLineNumber] int sourceLineNumber = 0)

--- a/Packages/Responsible/Runtime/TestWaitCondition.cs
+++ b/Packages/Responsible/Runtime/TestWaitCondition.cs
@@ -128,7 +128,7 @@ namespace Responsible
 		[Pure]
 		public static ITestInstruction<T> ExpectWithinSeconds<T>(
 			this ITestWaitCondition<T> condition,
-			int timeout,
+			double timeout,
 			[CallerMemberName] string memberName = "",
 			[CallerFilePath] string sourceFilePath = "",
 			[CallerLineNumber] int sourceLineNumber = 0)

--- a/Packages/Responsible/Runtime/TestWaitConditions/ConstraintWaitCondition.cs
+++ b/Packages/Responsible/Runtime/TestWaitConditions/ConstraintWaitCondition.cs
@@ -14,6 +14,16 @@ namespace Responsible.TestWaitConditions
 			Func<T> getObject,
 			IResolveConstraint constraint,
 			SourceContext sourceContext)
+			// Resolve() MUST be called only once!
+			: this(objectDescription, getObject, constraint.Resolve(), sourceContext)
+		{
+		}
+
+		private ConstraintWaitCondition(
+			string objectDescription,
+			Func<T> getObject,
+			IConstraint constraint,
+			SourceContext sourceContext)
 			: base(() => new State(objectDescription, getObject, constraint, sourceContext))
 		{
 		}
@@ -27,12 +37,12 @@ namespace Responsible.TestWaitConditions
 			public State(
 				string objectDescription,
 				Func<T> getObject,
-				IResolveConstraint constraint,
+				IConstraint constraint,
 				SourceContext sourceContext)
 				: base(sourceContext)
 			{
 				this.getObject = getObject;
-				this.constraint = constraint.Resolve();
+				this.constraint = constraint;
 				this.description = $"{objectDescription}: {this.constraint.Description}";
 			}
 

--- a/Packages/Responsible/Tests/Runtime/WaitForTests.cs
+++ b/Packages/Responsible/Tests/Runtime/WaitForTests.cs
@@ -157,6 +157,34 @@ namespace Responsible.Tests.Runtime
 		}
 
 		[UnityTest]
+		public IEnumerator WaitForFrames_CompletesAfterTimeout()
+		{
+			var completed = false;
+			using (WaitForFrames(2).ToObservable(this.Executor).Subscribe(_ => completed = true))
+			{
+				Assert.IsFalse(completed);
+				yield return null; // This frame
+				Assert.IsFalse(completed);
+				yield return null; // First frame
+				Assert.IsFalse(completed);
+				yield return null; // Second frame
+				Assert.IsTrue(completed);
+			}
+		}
+
+		[UnityTest]
+		public IEnumerator WaitForFrames_CompletesAfterThisFrame_WithZeroFrames()
+		{
+			var completed = false;
+			using (WaitForFrames(0).ToObservable(this.Executor).Subscribe(_ => completed = true))
+			{
+				Assert.IsFalse(completed);
+				yield return null; // This frame
+				Assert.IsTrue(completed);
+			}
+		}
+
+		[UnityTest]
 		public IEnumerator WaitForAllOf_Completes_AfterAllComplete()
 		{
 			var fulfilled1 = false;

--- a/Packages/Responsible/Tests/Runtime/WaitForTests.cs
+++ b/Packages/Responsible/Tests/Runtime/WaitForTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections;
 using NUnit.Framework;
-using Responsible.Tests.Runtime.Utilities;
 using UniRx;
 using UnityEngine.TestTools;
 using static Responsible.Responsibly;
@@ -11,6 +10,56 @@ namespace Responsible.Tests.Runtime
 {
 	public class WaitForTests : ResponsibleTestBase
 	{
+		[UnityTest]
+		public IEnumerator WaitForConditionOn_Completes_OnlyWhenConditionIsTrueOnReturnedObject()
+		{
+			var completed = false;
+			object boxedBool = null;
+
+			using (WaitForConditionOn(
+					"Wait for boxedBool to be true",
+					() => boxedBool,
+					obj => obj is bool asBool && asBool)
+				.ExpectWithinSeconds(10)
+				.ToObservable(this.Executor)
+				.Subscribe(_ => completed = true))
+			{
+				Assert.IsFalse(completed);
+				yield return null;
+
+				// Completes on next frame
+				boxedBool = true;
+				Assert.IsFalse(completed);
+				yield return null;
+				Assert.IsTrue(completed);
+			}
+		}
+
+		[UnityTest]
+		public IEnumerator WaitForConditionOn_RunsSelector_WhenResultSelectorProvided()
+		{
+			bool? result = null;
+			object boxedBool = null;
+
+			using (WaitForConditionOn(
+					"Wait for boxedBool to be true",
+					() => boxedBool,
+					obj => obj is bool asBool && asBool,
+					val => !(bool)val)
+				.ExpectWithinSeconds(10)
+				.ToObservable(this.Executor)
+				.Subscribe(val => result = val))
+			{
+				Assert.IsNull(result);
+				yield return null;
+
+				// Completes on next frame
+				boxedBool = true;
+				yield return null;
+				Assert.IsFalse(result, "The result should be negated by the result selector");
+			}
+		}
+
 		[UnityTest]
 		public IEnumerator WaitForCondition_Completes_WhenConditionMet()
 		{


### PR DESCRIPTION
* Add new `WaitForConditionOn` to allow cleaner and more optimized use
* Fix referential transparency of WaitForConstraint: `Resolve()` must only be called once!
* Change `...Seconds` operators to take `double` instead of `int`, this should be backwards compatible in practice
* Add `WaitForFrames` operator. Not the best practice, but e.g. if you want to repeat the same action on multiple frames, it's pretty necessary (wait conditions are optimized for same-frame completion)