### PR TITLE
Add error context to ExpectWithinSeconds operators

### DIFF
--- a/Assets/Tests/Runtime/ErrorOutputTests.cs
+++ b/Assets/Tests/Runtime/ErrorOutputTests.cs
@@ -118,6 +118,14 @@ Failure context:
         [ ] ...
       THEN RESPOND WITH ...
  
+Failed with:
+  System.Exception: 'Exception'
+ 
+Test operation stack:
+  [ExpectWithinSeconds] MakeInstruction (at Assets/Tests/Runtime/ErrorOutputTests.cs:34)
+  [ToObservable] ErrorOutput_IsAsExpected (at Assets/Tests/Runtime/ErrorOutputTests.cs:67)
+ 
+ 
 Error: System.Exception: Exception";
 	}
 }

--- a/Assets/Tests/Runtime/ExpectWithinSecondsTests.cs
+++ b/Assets/Tests/Runtime/ExpectWithinSecondsTests.cs
@@ -1,0 +1,102 @@
+using System;
+using NUnit.Framework;
+using UniRx;
+using static Responsible.Responsibly;
+
+namespace Responsible.Tests.Runtime
+{
+	public class ExpectWithinSecondsTests : ResponsibleTestBase
+	{
+		[Test]
+		public void ExpectCondition_TerminatesWithError_AfterTimeout()
+		{
+			Never
+				.ExpectWithinSeconds(1)
+				.ToObservable(this.Executor)
+				.Subscribe(Nop, this.StoreError);
+
+			Assert.IsNull(this.Error);
+			this.Scheduler.AdvanceBy(OneSecond);
+			Assert.IsInstanceOf<AssertionException>(this.Error);
+		}
+
+		[Test]
+		public void ExpectCondition_ContainsErrorDetails_WhenTimedOut()
+		{
+			this.AssertErrorDetailsAfterOneSecond(Never.ExpectWithinSeconds(1));
+		}
+
+		[Test]
+		public void ExpectCondition_ContainsErrorDetails_WhenExceptionThrown()
+		{
+			this.AssertErrorDetailsAfterOneSecond(
+				WaitForCondition(
+						"Throwing condition",
+						() => throw new Exception("Test"))
+					.ExpectWithinSeconds(1));
+		}
+
+		[Test]
+		public void ExpectResponder_TerminatesWithError_IfWaitNotFulfilled()
+		{
+			Never
+				.ThenRespondWith("NOP", Nop)
+				.ExpectWithinSeconds(1)
+				.ToObservable(this.Executor)
+				.Subscribe(Nop, this.StoreError);
+
+			Assert.IsNull(this.Error);
+			this.Scheduler.AdvanceBy(OneSecond);
+			Assert.IsInstanceOf<AssertionException>(this.Error);
+		}
+
+		[Test]
+		public void ExpectResponder_DoesNotTerminateWithTimeout_IfWaitFulfilled()
+		{
+			var completed = false;
+
+			// The instruction takes longer than the timeout
+			// => The timeout applies only to the wait!
+			ImmediateTrue
+				.ThenRespondWith("Wait for two seconds", WaitForSeconds(2))
+				.ExpectWithinSeconds(1)
+				.ToObservable(this.Executor)
+				.Subscribe(_ => completed = true, this.StoreError);
+
+			this.Scheduler.AdvanceBy(OneSecond);
+			Assert.IsNull(this.Error);
+			Assert.IsFalse(completed);
+
+			this.Scheduler.AdvanceBy(OneSecond);
+			Assert.IsNull(this.Error);
+			Assert.IsTrue(completed);
+		}
+
+		[Test]
+		public void ExpectResponder_ContainsErrorDetails_WhenTimedOut()
+		{
+			var responder = Never.ThenRespondWith("NOP", Nop);
+			this.AssertErrorDetailsAfterOneSecond(responder.ExpectWithinSeconds(1));
+		}
+
+		[Test]
+		public void ExpectResponder_ContainsErrorDetails_WhenExceptionThrown()
+		{
+			var responder = ImmediateTrue.ThenRespondWith("Throw error", _ => throw new Exception("Test"));
+			this.AssertErrorDetailsAfterOneSecond(responder.ExpectWithinSeconds(1));
+		}
+
+		private void AssertErrorDetailsAfterOneSecond(ITestInstruction<Unit> instruction)
+		{
+			instruction
+				.ToObservable(this.Executor)
+				.Subscribe(Nop, this.StoreError);
+
+			this.Scheduler.AdvanceBy(OneSecond);
+
+			Assert.IsInstanceOf<AssertionException>(this.Error);
+			StringAssert.Contains("Test operation stack", this.Error.Message);
+			StringAssert.Contains("Failed with", this.Error.Message);
+		}
+	}
+}

--- a/Assets/Tests/Runtime/ExpectWithinSecondsTests.cs.meta
+++ b/Assets/Tests/Runtime/ExpectWithinSecondsTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 44174e927e9c40cd9f3e93a6d45bcea8
+timeCreated: 1604590726

--- a/ProjectSettings/EditorSettings.asset
+++ b/ProjectSettings/EditorSettings.asset
@@ -17,7 +17,7 @@ EditorSettings:
   m_EtcTextureNormalCompressor: 2
   m_EtcTextureBestCompressor: 4
   m_ProjectGenerationIncludedExtensions: txt;xml;fnt;cd;asmref
-  m_ProjectGenerationRootNamespace: 
+  m_ProjectGenerationRootNamespace: Responsible
   m_CollabEditorSettings:
     inProgressEnabled: 1
   m_EnableTextureStreamingInEditMode: 1

--- a/Responsible.csproj.DotSettings
+++ b/Responsible.csproj.DotSettings
@@ -1,3 +1,3 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=packages/@EntryIndexedValue">True</s:Boolean>
+	
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=packages_005Cresponsible_005Cruntime/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
This is especially useful for timeouts, which often lack source context completely.