### PR TITLE
Add canceled state to outputs

### DIFF
--- a/Assets/Responsible/Tests/Runtime/ErrorOutputTests.cs
+++ b/Assets/Responsible/Tests/Runtime/ErrorOutputTests.cs
@@ -23,15 +23,27 @@ namespace Responsible.Tests.Runtime
 			public Action ResponseAction { get; set; }
 		}
 
+		private static ITestWaitCondition<Unit> MakeOptionalResponder(ResponderState state) =>
+			WaitForCondition(state.Condition1Name, () => state.Condition1)
+				.ThenRespondWith(state.ResponseName, _ => state.ResponseAction)
+				.Optionally()
+				.Until(WaitForCondition(state.Condition2Name, () => state.Condition2));
+
 		private static ITestResponder<Unit> MakeResponder(ResponderState state) =>
 			WaitForCondition(state.Condition1Name, () => state.Condition1)
 				.AndThen(_ => WaitForCondition(state.Condition2Name, () => state.Condition2))
 				.ThenRespondWith(state.ResponseName, _ => state.ResponseAction());
 
-		private static ITestInstruction<Unit> MakeInstruction(ResponderState state1, ResponderState state2) =>
-			RespondToAnyOf(MakeResponder(state1), MakeResponder(state2))
-				.Until(WaitForCondition("Never", () => false))
-				.ExpectWithinSeconds(10);
+		private static ITestInstruction<Unit> MakeInstruction(
+			ResponderState state1,
+			ResponderState state2,
+			ResponderState state3) =>
+			MakeOptionalResponder(state1)
+				.ExpectWithinSeconds(10)
+				.ContinueWith(
+					RespondToAnyOf(MakeResponder(state2), MakeResponder(state3))
+						.Until(WaitForCondition("Never", () => false))
+						.ExpectWithinSeconds(10));
 
 		[Test]
 		public void ErrorOutput_IsAsExpected()
@@ -53,7 +65,6 @@ namespace Responsible.Tests.Runtime
 					Condition1Name = "Cond 1.1",
 					Condition2Name = "Cond 1.2",
 					ResponseName = "Response 1",
-					ResponseAction = () => throw new Exception("Exception"),
 				};
 
 				var state2 = new ResponderState
@@ -61,9 +72,17 @@ namespace Responsible.Tests.Runtime
 					Condition1Name = "Cond 2.1",
 					Condition2Name = "Cond 2.2",
 					ResponseName = "Response 2",
+					ResponseAction = () => throw new Exception("Exception"),
 				};
 
-				MakeInstruction(state1, state2)
+				var state3 = new ResponderState
+				{
+					Condition1Name = "Cond 3.1",
+					Condition2Name = "Cond 3.2",
+					ResponseName = "Response 3",
+				};
+
+				MakeInstruction(state1, state2, state3)
 					.ToObservable(executor)
 					.CatchIgnore()
 					.Subscribe();
@@ -72,18 +91,25 @@ namespace Responsible.Tests.Runtime
 				string message = null;
 				logger.Log(LogType.Error, Arg.Do<string>(msg => message = msg));
 
-				// Advance time and frames, and complete one condition
-				scheduler.AdvanceBy(TimeSpan.FromSeconds(1.5));
-				poll.OnNext(Unit.Default);
-				state1.Condition1 = true;
-				poll.OnNext(Unit.Default);
-
-				// Advance time and frames, and complete second condition
-				scheduler.AdvanceBy(TimeSpan.FromSeconds(1.5));
+				// Advance time and frames, and complete condition that cancels the first wait
+				scheduler.AdvanceBy(TimeSpan.FromMilliseconds(20));
 				poll.OnNext(Unit.Default);
 				state1.Condition2 = true;
 				poll.OnNext(Unit.Default);
 
+				// Advance time and frames, and complete one condition of second responder
+				scheduler.AdvanceBy(TimeSpan.FromMilliseconds(20));
+				poll.OnNext(Unit.Default);
+				state2.Condition1 = true;
+				poll.OnNext(Unit.Default);
+
+				// Advance time and frames, and complete second condition of second responder
+				scheduler.AdvanceBy(TimeSpan.FromMilliseconds(20));
+				poll.OnNext(Unit.Default);
+				state2.Condition2 = true;
+				poll.OnNext(Unit.Default);
+
+				// Second responder should trigger error, third one is not executed
 				StringAssert.StartsWith(ExpectedOutput, message);
 			}
 		}
@@ -92,29 +118,38 @@ namespace Responsible.Tests.Runtime
 			@"Test operation execution failed!
  
 Failure context:
-[!] EXPECT WITHIN 0:00:10 (Failed after 3.00s and 4 frames)
+[✓] EXPECT WITHIN 0:00:10 (Completed in 0.02s and 2 frames)
   UNTIL
-    [.] Never (Started 3.00s and 4 frames ago)
+    [✓] Cond 1.2 (Completed in 0.02s and 2 frames)
   RESPOND TO ANY OF
-    [!] Response 1 (Failed after 0.00s and 0 frames)
+    [-] Response 1 (Canceled after 0.02s and 1 frames)
       WAIT FOR
-        [✓] Cond 1.1 (Completed in 1.50s and 2 frames)
-        [.] Cond 1.2 (Started 1.50s and 2 frames ago)
+        [-] Cond 1.1 (Canceled after 0.02s and 1 frames)
+      THEN RESPOND WITH ...
+[!] EXPECT WITHIN 0:00:10 (Failed after 0.04s and 4 frames)
+  UNTIL
+    [.] Never (Started 0.04s and 4 frames ago)
+  RESPOND TO ANY OF
+    [!] Response 2 (Failed after 0.00s and 0 frames)
+      WAIT FOR
+        [✓] Cond 2.1 (Completed in 0.02s and 2 frames)
+        [.] Cond 2.2 (Started 0.02s and 2 frames ago)
       THEN RESPOND WITH
-        [!] Response 1 (Failed after 0.00s and 0 frames)
+        [!] Response 2 (Failed after 0.00s and 0 frames)
  
           Failed with:
             System.Exception: 'Exception'
  
           Test operation stack:
-            [ThenRespondWith] MakeResponder (at Assets/Responsible/Tests/Runtime/ErrorOutputTests.cs:29)
-            [Until] MakeInstruction (at Assets/Responsible/Tests/Runtime/ErrorOutputTests.cs:33)
-            [ExpectWithinSeconds] MakeInstruction (at Assets/Responsible/Tests/Runtime/ErrorOutputTests.cs:34)
-            [ToObservable] ErrorOutput_IsAsExpected (at Assets/Responsible/Tests/Runtime/ErrorOutputTests.cs:67)
+            [ThenRespondWith] MakeResponder (at Assets/Responsible/Tests/Runtime/ErrorOutputTests.cs:35)
+            [Until] MakeInstruction (at Assets/Responsible/Tests/Runtime/ErrorOutputTests.cs:45)
+            [ExpectWithinSeconds] MakeInstruction (at Assets/Responsible/Tests/Runtime/ErrorOutputTests.cs:46)
+            [ContinueWith] MakeInstruction (at Assets/Responsible/Tests/Runtime/ErrorOutputTests.cs:43)
+            [ToObservable] ErrorOutput_IsAsExpected (at Assets/Responsible/Tests/Runtime/ErrorOutputTests.cs:86)
  
-    [.] Response 2 (Started 3.00s and 4 frames ago)
+    [.] Response 3 (Started 0.04s and 4 frames ago)
       WAIT FOR
-        [.] Cond 2.1 (Started 3.00s and 4 frames ago)
+        [.] Cond 3.1 (Started 0.04s and 4 frames ago)
         [ ] ...
       THEN RESPOND WITH ...
  
@@ -122,8 +157,9 @@ Failed with:
   System.Exception: 'Exception'
  
 Test operation stack:
-  [ExpectWithinSeconds] MakeInstruction (at Assets/Responsible/Tests/Runtime/ErrorOutputTests.cs:34)
-  [ToObservable] ErrorOutput_IsAsExpected (at Assets/Responsible/Tests/Runtime/ErrorOutputTests.cs:67)
+  [ExpectWithinSeconds] MakeInstruction (at Assets/Responsible/Tests/Runtime/ErrorOutputTests.cs:46)
+  [ContinueWith] MakeInstruction (at Assets/Responsible/Tests/Runtime/ErrorOutputTests.cs:43)
+  [ToObservable] ErrorOutput_IsAsExpected (at Assets/Responsible/Tests/Runtime/ErrorOutputTests.cs:86)
  
  
 Error: System.Exception: Exception";

--- a/Assets/Responsible/Tests/Runtime/WaitForConditionTests.cs
+++ b/Assets/Responsible/Tests/Runtime/WaitForConditionTests.cs
@@ -117,7 +117,7 @@ namespace Responsible.Tests.Runtime
 			var extraContextRequested = false;
 
 			var respond = WaitForCondition(
-					"Never",
+					"Should be canceled",
 					() => false,
 					_ => extraContextRequested = true)
 				.ThenRespondWith("Do nothing", Nop);
@@ -138,7 +138,7 @@ namespace Responsible.Tests.Runtime
 
 				Assert.IsInstanceOf<AssertionException>(this.Error);
 				Assert.IsFalse(extraContextRequested, "Should not request extra context when canceled");
-				Assert.That(this.Error.Message, Does.Match(@"\[-\].*Never.*[Cc]anceled"));
+				Assert.That(this.Error.Message, Does.Match(@"\[-\].*Should be canceled.*[Cc]anceled"));
 			}
 		}
 	}

--- a/Assets/Responsible/Tests/Runtime/WaitForConditionTests.cs
+++ b/Assets/Responsible/Tests/Runtime/WaitForConditionTests.cs
@@ -91,5 +91,55 @@ namespace Responsible.Tests.Runtime
 
 			Assert.IsTrue(result);
 		}
+
+		[UnityTest]
+		public IEnumerator WaitForCondition_LogsDetails_WhenTimedOut()
+		{
+			using (WaitForCondition(
+					"Never",
+					() => false,
+					builder => builder.AddDetails("Should be in output"))
+				.ExpectWithinSeconds(1)
+				.ToObservable(this.Executor)
+				.Subscribe(Nop, this.StoreError))
+			{
+				this.Scheduler.AdvanceBy(TimeSpan.FromSeconds(2));
+				yield return null;
+
+				Assert.IsInstanceOf<AssertionException>(this.Error);
+				StringAssert.Contains("Should be in output", this.Error.Message);
+			}
+		}
+
+		[UnityTest]
+		public IEnumerator WaitForCondition_LogsCorrectDetails_WhenCanceled()
+		{
+			var extraContextRequested = false;
+
+			var respond = WaitForCondition(
+					"Never",
+					() => false,
+					_ => extraContextRequested = true)
+				.ThenRespondWith("Do nothing", Nop);
+
+			// Never execute the optional responder, leading to the wait being canceled.
+			// But error out afterwards, to get a failure message.
+			// We could do this in a simpler way using CreateState,
+			// but that would not be as realistic.
+			using (respond.Optionally()
+				.Until(ImmediateTrue)
+				.AndThen(Never)
+				.ExpectWithinSeconds(1)
+				.ToObservable(this.Executor)
+				.Subscribe(Nop, this.StoreError))
+			{
+				this.Scheduler.AdvanceBy(TimeSpan.FromSeconds(2));
+				yield return null;
+
+				Assert.IsInstanceOf<AssertionException>(this.Error);
+				Assert.IsFalse(extraContextRequested, "Should not request extra context when canceled");
+				Assert.That(this.Error.Message, Does.Match(@"\[-\].*Never.*[Cc]anceled"));
+			}
+		}
 	}
 }

--- a/Packages/Responsible/Runtime/State/TestOperationState.cs
+++ b/Packages/Responsible/Runtime/State/TestOperationState.cs
@@ -28,6 +28,7 @@ namespace Responsible.State
 			return this
 				.ExecuteInner(nestedRunContext)
 				.DoOnCompleted(() => this.Status = new TestOperationStatus.Completed(this.Status))
+				.DoOnCancel(() => this.Status = new TestOperationStatus.Canceled(this.Status))
 				.DoOnError(exception => this.Status =
 					new TestOperationStatus.Failed(this.Status, exception, nestedRunContext.SourceContext))
 				.Finally(() => waitContext.Dispose());

--- a/Packages/Responsible/Runtime/State/TestOperationStatus.cs
+++ b/Packages/Responsible/Runtime/State/TestOperationStatus.cs
@@ -68,6 +68,20 @@ namespace Responsible.State
 				$"[!] {description} (Failed after {this.elapsedTime})";
 		}
 
+		internal class Canceled : TestOperationStatus
+		{
+			private readonly string elapsedTime;
+
+			public Canceled(TestOperationStatus previous)
+			{
+				var waiting = this.ExpectWaiting(previous);
+				this.elapsedTime = waiting.WaitContext.ElapsedTime;
+			}
+
+			public override string MakeStatusLine(string description) =>
+				$"[-] {description} (Canceled after {this.elapsedTime})";
+		}
+
 		[ExcludeFromCodeCoverage] // Unreachable defensive code
 		public static void AssertNotStarted(TestOperationStatus status)
 		{


### PR DESCRIPTION
This makes optional responders that never executed look a lot better.

By lucky accident, this doesn't actually show sub-operations of a failed operation as canceled, but shows full details for them. Just like I would want it to do :) 