### PR TITLE
Simplify output of ExpectWithinSeconds with basic responders

### DIFF
--- a/Packages/Responsible/Runtime/State/IBasicResponderState.cs
+++ b/Packages/Responsible/Runtime/State/IBasicResponderState.cs
@@ -1,0 +1,15 @@
+using JetBrains.Annotations;
+
+namespace Responsible.State
+{
+	/// <summary>
+	/// Operation state for a basic responder, the description of which can be inlined
+	/// with an expect within operation.
+	/// </summary>
+	internal interface IBasicResponderState : ITestOperationState
+	{
+		string Description { get; }
+		ITestOperationState WaitState { get; }
+		[CanBeNull] ITestOperationState InstructionState { get; }
+	}
+}

--- a/Packages/Responsible/Runtime/State/IBasicResponderState.cs.meta
+++ b/Packages/Responsible/Runtime/State/IBasicResponderState.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: cafdea88542c4cd2b0b2af9ef7b1f38b
+timeCreated: 1606049578

--- a/Packages/Responsible/Runtime/State/IDiscreteWaitConditionState.cs
+++ b/Packages/Responsible/Runtime/State/IDiscreteWaitConditionState.cs
@@ -7,7 +7,7 @@ namespace Responsible.State
 	/// A discrete, or singular, wait state, which can be combined with
 	/// expect within operations in output.
 	/// </summary>
-	public interface IDiscreteWaitConditionState : ITestOperationState
+	internal interface IDiscreteWaitConditionState : ITestOperationState
 	{
 		string Description { get; }
 		[CanBeNull] Action<StateStringBuilder> ExtraContext { get; }

--- a/Packages/Responsible/Runtime/TestResponders/TestResponder.cs
+++ b/Packages/Responsible/Runtime/TestResponders/TestResponder.cs
@@ -17,13 +17,14 @@ namespace Responsible.TestResponders
 		{
 		}
 
-		private class State : TestOperationState<ITestOperationState<T>>
+		private class State : TestOperationState<ITestOperationState<T>>, IBasicResponderState
 		{
-			private readonly string description;
 			private readonly ITestOperationState<TArg> waitCondition;
 			private readonly Func<TArg, ITestInstruction<T>> makeInstruction;
 
-			[CanBeNull] private ITestOperationState<T> instructionState;
+			public string Description { get; }
+			public ITestOperationState WaitState => this.waitCondition;
+			public ITestOperationState InstructionState { get; private set; }
 
 			public State(
 				string description,
@@ -32,7 +33,7 @@ namespace Responsible.TestResponders
 				SourceContext sourceContext)
 				: base(sourceContext)
 			{
-				this.description = description;
+				this.Description = description;
 				this.waitCondition = waitCondition.CreateState();
 				this.makeInstruction = makeInstruction;
 			}
@@ -41,10 +42,9 @@ namespace Responsible.TestResponders
 				this.waitCondition
 					.Execute(runContext)
 					.Select(arg => this.makeInstruction(arg).CreateState())
-					.Do(instruction => this.instructionState = instruction);
+					.Do(instruction => this.InstructionState = instruction);
 
-			public override void BuildDescription(StateStringBuilder builder)
-				=> builder.AddResponder(this.description, this, this.waitCondition, this.instructionState);
+			public override void BuildDescription(StateStringBuilder builder) => builder.AddResponder(this);
 		}
 	}
 }


### PR DESCRIPTION
Instead of e.g.
```
[!] EXPECT WITHIN ...
  [!] Responder ...
    WAIT FOR
      [✓] ...
    THEN RESPOND WITH
      [!] Response
```

Just show

```
[!] Responder EXPECTED WITHIN ...
  WAIT FOR
    [✓] ...
  THEN RESPOND WITH
    [!] Response
```

Similar to #20 but for basic responders - does not affect until-responders.