### PR TITLE
Simplify public API

### DIFF
--- a/Assets/Responsible/Tests/Runtime/AsUnitTests.cs
+++ b/Assets/Responsible/Tests/Runtime/AsUnitTests.cs
@@ -12,14 +12,14 @@ namespace Responsible.Tests.Runtime
 		private bool complete;
 		private bool completed;
 
-		private ITestWaitCondition<bool> waitForComplete;
+		private ITestWaitCondition<Unit> waitForComplete;
 		private ITestInstruction<bool> setCompleted;
 		private ITestInstruction<int> throwError;
 
 		[OneTimeSetUp]
 		public void OneTimeSetUp()
 		{
-			this.waitForComplete = WaitForCondition("Wait", () => this.complete, () => this.complete);
+			this.waitForComplete = WaitForCondition("Wait", () => this.complete);
 			this.setCompleted = DoAndReturn("Set completed", () => this.completed = true);
 			this.throwError = DoAndReturn<int>("Throw error", () => throw new Exception(""));
 		}
@@ -89,7 +89,7 @@ namespace Responsible.Tests.Runtime
 		[Test]
 		public void AsUnitCondition_ReturnsSelf_WhenAlreadyUnit()
 		{
-			var condition = WaitForCondition("Unit", () => false, () => Unit.Default);
+			var condition = WaitForCondition("Unit", () => false);
 			Assert.AreSame(condition, condition.AsUnitCondition());
 		}
 

--- a/Assets/Responsible/Tests/Runtime/AsUnitTests.cs
+++ b/Assets/Responsible/Tests/Runtime/AsUnitTests.cs
@@ -12,14 +12,14 @@ namespace Responsible.Tests.Runtime
 		private bool complete;
 		private bool completed;
 
-		private ITestWaitCondition<Unit> waitForComplete;
+		private ITestWaitCondition<bool> waitForComplete;
 		private ITestInstruction<bool> setCompleted;
 		private ITestInstruction<int> throwError;
 
 		[OneTimeSetUp]
 		public void OneTimeSetUp()
 		{
-			this.waitForComplete = WaitForCondition("Wait", () => this.complete);
+			this.waitForComplete = WaitForConditionOn("Wait", () => this.complete, val => val);
 			this.setCompleted = DoAndReturn("Set completed", () => this.completed = true);
 			this.throwError = DoAndReturn<int>("Throw error", () => throw new Exception(""));
 		}

--- a/Assets/Responsible/Tests/Runtime/CoroutineTests.cs
+++ b/Assets/Responsible/Tests/Runtime/CoroutineTests.cs
@@ -15,11 +15,6 @@ namespace Responsible.Tests.Runtime
 			yield return null;
 		}
 
-		private static IEnumerator CompleteAfterOneFrame()
-		{
-			yield return null;
-		}
-
 		private static IEnumerator ThrowAfterOneFrame()
 		{
 			yield return null;
@@ -30,7 +25,7 @@ namespace Responsible.Tests.Runtime
 		public IEnumerator WaitForCoroutine_Completes_WhenExpected()
 		{
 			var completed = false;
-			WaitForCoroutine(CompleteAfterTwoFrames)
+			WaitForCoroutineMethod(CompleteAfterTwoFrames)
 				.ExpectWithinSeconds(1)
 				.ToObservable(this.Executor)
 				.Subscribe(_ => completed = true);
@@ -43,24 +38,10 @@ namespace Responsible.Tests.Runtime
 		}
 
 		[UnityTest]
-		public IEnumerator WaitForCoroutine_ReturnsResult_WhenProvided()
-		{
-			int? result = null;
-			WaitForCoroutine(CompleteAfterOneFrame, () => 42)
-				.ExpectWithinSeconds(1)
-				.ToObservable(this.Executor)
-				.Subscribe(r => result = r);
-
-			Assert.IsNull(result, "Should not publish result before any yields");
-			yield return null;
-			Assert.AreEqual(42, result, "Should have provided result after yield");
-		}
-
-		[UnityTest]
 		public IEnumerator WaitForCoroutine_PublishesErrorWithContext_WhenExpected()
 		{
 			var completed = false;
-			WaitForCoroutine(ThrowAfterOneFrame)
+			WaitForCoroutineMethod(ThrowAfterOneFrame)
 				.ExpectWithinSeconds(1)
 				.ToObservable(this.Executor)
 				.Subscribe(Nop, this.StoreError);
@@ -82,7 +63,7 @@ namespace Responsible.Tests.Runtime
 				yield break;
 			}
 
-			var description = WaitForCoroutine(LocalCoroutine, "LocalCoroutine").CreateState().ToString();
+			var description = WaitForCoroutine("LocalCoroutine", LocalCoroutine).CreateState().ToString();
 			Assert.That(description, Does.Contain("[ ] LocalCoroutine"));
 		}
 	}

--- a/Assets/Responsible/Tests/Runtime/ErrorOutputTests.cs
+++ b/Assets/Responsible/Tests/Runtime/ErrorOutputTests.cs
@@ -25,14 +25,14 @@ namespace Responsible.Tests.Runtime
 
 		private static ITestWaitCondition<Unit> MakeOptionalResponder(ResponderState state) =>
 			WaitForCondition(state.Condition1Name, () => state.Condition1)
-				.ThenRespondWith(state.ResponseName, _ => state.ResponseAction)
+				.ThenRespondWithAction(state.ResponseName, _ => state.ResponseAction())
 				.Optionally()
 				.Until(WaitForCondition(state.Condition2Name, () => state.Condition2));
 
 		private static ITestResponder<Unit> MakeResponder(ResponderState state) =>
 			WaitForCondition(state.Condition1Name, () => state.Condition1)
 				.AndThen(_ => WaitForCondition(state.Condition2Name, () => state.Condition2))
-				.ThenRespondWith(state.ResponseName, _ => state.ResponseAction());
+				.ThenRespondWithAction(state.ResponseName, _ => state.ResponseAction());
 
 		private static ITestInstruction<Unit> MakeInstruction(
 			ResponderState state1,
@@ -141,7 +141,7 @@ Failure context:
             System.Exception: 'Exception'
  
           Test operation stack:
-            [ThenRespondWith] MakeResponder (at Assets/Responsible/Tests/Runtime/ErrorOutputTests.cs:35)
+            [ThenRespondWithAction] MakeResponder (at Assets/Responsible/Tests/Runtime/ErrorOutputTests.cs:35)
             [Until] MakeInstruction (at Assets/Responsible/Tests/Runtime/ErrorOutputTests.cs:45)
             [ExpectWithinSeconds] MakeInstruction (at Assets/Responsible/Tests/Runtime/ErrorOutputTests.cs:46)
             [ContinueWith] MakeInstruction (at Assets/Responsible/Tests/Runtime/ErrorOutputTests.cs:43)

--- a/Assets/Responsible/Tests/Runtime/ExpectWithinSecondsTests.cs
+++ b/Assets/Responsible/Tests/Runtime/ExpectWithinSecondsTests.cs
@@ -80,7 +80,7 @@ namespace Responsible.Tests.Runtime
 		public void ExpectResponder_TerminatesWithError_IfWaitNotFulfilled()
 		{
 			Never
-				.ThenRespondWith("NOP", Nop)
+				.ThenRespondWithAction("NOP", Nop)
 				.ExpectWithinSeconds(1)
 				.ToObservable(this.Executor)
 				.Subscribe(Nop, this.StoreError);
@@ -115,7 +115,7 @@ namespace Responsible.Tests.Runtime
 		[Test]
 		public void ExpectResponder_ContainsErrorDetails_WhenConditionTimedOut()
 		{
-			var responder = Never.ThenRespondWith("Nop", Nop);
+			var responder = Never.ThenRespondWithAction("Nop", Nop);
 			this.AssertErrorDetailsAfterOneSecond(
 				responder.ExpectWithinSeconds(1),
 				@"timed out.*
@@ -140,7 +140,7 @@ Test operation stack");
 		[Test]
 		public void ExpectResponder_ContainsErrorDetails_WhenExceptionThrown()
 		{
-			var responder = ImmediateTrue.ThenRespondWith("Throw error", _ => throw new Exception("Test"));
+			var responder = ImmediateTrue.ThenRespondWithAction("Throw error", _ => throw new Exception("Test"));
 			this.AssertErrorDetailsAfterOneSecond(
 				responder.ExpectWithinSeconds(1),
 				@"failed.*

--- a/Assets/Responsible/Tests/Runtime/ResponsibleTestBase.cs
+++ b/Assets/Responsible/Tests/Runtime/ResponsibleTestBase.cs
@@ -11,7 +11,7 @@ namespace Responsible.Tests.Runtime
 	public class ResponsibleTestBase
 	{
 		protected static readonly ITestWaitCondition<bool> ImmediateTrue =
-			WaitForCondition("True", () => true, () => true);
+			WaitForConditionOn("True", () => true, val => val);
 
 		protected static readonly ITestWaitCondition<Unit> Never =
 			WaitForCondition("Never", () => false);

--- a/Assets/Responsible/Tests/Runtime/ThenRespondWithTests.cs
+++ b/Assets/Responsible/Tests/Runtime/ThenRespondWithTests.cs
@@ -14,7 +14,7 @@ namespace Responsible.Tests.Runtime
 		{
 			Continuation,
 			Instruction,
-			Selector,
+			Func,
 			Action
 		}
 
@@ -76,10 +76,10 @@ namespace Responsible.Tests.Runtime
 					return waitCondition.ThenRespondWith("Respond", x => Return(Unit.Default));
 				case ConstructionStrategy.Instruction:
 					return waitCondition.ThenRespondWith("Respond", Return(Unit.Default));
-				case ConstructionStrategy.Selector:
-					return waitCondition.ThenRespondWith("Respond", _ => Unit.Default);
+				case ConstructionStrategy.Func:
+					return waitCondition.ThenRespondWithFunc("Respond", _ => Unit.Default);
 				case ConstructionStrategy.Action:
-					return waitCondition.ThenRespondWith("Respond", _ => { });
+					return waitCondition.ThenRespondWithAction("Respond", _ => { });
 				default:
 					throw new ArgumentOutOfRangeException(nameof(strategy), strategy, "Unhandled strategy");
 			}
@@ -97,10 +97,10 @@ namespace Responsible.Tests.Runtime
 					return waitCondition.ThenRespondWith("Respond", x => throwInstruction);
 				case ConstructionStrategy.Instruction:
 					return waitCondition.ThenRespondWith("Respond", throwInstruction);
-				case ConstructionStrategy.Selector:
-					return waitCondition.ThenRespondWith("Respond", ThrowException);
+				case ConstructionStrategy.Func:
+					return waitCondition.ThenRespondWithFunc("Respond", ThrowException);
 				case ConstructionStrategy.Action:
-					return waitCondition.ThenRespondWith("Respond", _ => { ThrowException(_); });
+					return waitCondition.ThenRespondWithAction("Respond", _ => { ThrowException(_); });
 				default:
 					throw new ArgumentOutOfRangeException(nameof(strategy), strategy, "Unhandled strategy");
 			}

--- a/Assets/Responsible/Tests/Runtime/UntilTests.cs
+++ b/Assets/Responsible/Tests/Runtime/UntilTests.cs
@@ -61,7 +61,7 @@ namespace Responsible.Tests.Runtime
 			var secondCompleted = false;
 
 			var state = WaitForCondition("Wait for first cond", () => cond1)
-				.ThenRespondWith("First response", _ => firstCompleted = true)
+				.ThenRespondWithAction("First response", _ => firstCompleted = true)
 				.Optionally()
 				.Until(WaitForCondition("Until cond", () => untilCond))
 				.ThenRespondWith("Second response", WaitForCondition("Second cond", () => cond2)
@@ -101,7 +101,7 @@ namespace Responsible.Tests.Runtime
 			var completed = false;
 
 			Never
-				.ThenRespondWith("complete", _ => completed = true)
+				.ThenRespondWithAction("complete", _ => completed = true)
 				.Optionally()
 				.Until(Never)
 				.ExpectWithinSeconds(1)

--- a/Assets/Responsible/Tests/Runtime/WaitForAllOfTests.cs
+++ b/Assets/Responsible/Tests/Runtime/WaitForAllOfTests.cs
@@ -18,10 +18,12 @@ namespace Responsible.Tests.Runtime
 			var fulfilled3 = false;
 			bool[] results = null;
 
+			bool Id(bool val) => val;
+
 			using (WaitForAllOf(
-					WaitForCondition("cond 1", () => fulfilled1, () => true),
-					WaitForCondition("cond 2", () => fulfilled2, () => false),
-					WaitForCondition("cond 3", () => fulfilled3, () => false))
+					WaitForConditionOn("cond 1", () => fulfilled1, Id),
+					WaitForConditionOn("cond 2", () => fulfilled2, Id),
+					WaitForConditionOn("cond 3", () => fulfilled3, Id))
 				.ExpectWithinSeconds(10)
 				.ToObservable(this.Executor)
 				.Subscribe(val => results = val))
@@ -44,7 +46,7 @@ namespace Responsible.Tests.Runtime
 				// Completes on next frame
 				yield return null;
 				Assert.AreEqual(
-					new[] { true, false, false },
+					new[] { true, true, true },
 					results);
 			}
 		}

--- a/Assets/Responsible/Tests/Runtime/WaitForConditionTests.cs
+++ b/Assets/Responsible/Tests/Runtime/WaitForConditionTests.cs
@@ -36,31 +36,6 @@ namespace Responsible.Tests.Runtime
 		}
 
 		[UnityTest]
-		public IEnumerator WaitForConditionOn_RunsSelector_WhenResultSelectorProvided()
-		{
-			bool? result = null;
-			object boxedBool = null;
-
-			using (WaitForConditionOn(
-					"Wait for boxedBool to be true",
-					() => boxedBool,
-					obj => obj is bool asBool && asBool,
-					val => !(bool)val)
-				.ExpectWithinSeconds(10)
-				.ToObservable(this.Executor)
-				.Subscribe(val => result = val))
-			{
-				Assert.IsNull(result);
-				yield return null;
-
-				// Completes on next frame
-				boxedBool = true;
-				yield return null;
-				Assert.IsFalse(result, "The result should be negated by the result selector");
-			}
-		}
-
-		[UnityTest]
 		public IEnumerator WaitForCondition_Completes_WhenConditionMet()
 		{
 			var fulfilled = false;

--- a/Assets/Responsible/Tests/Runtime/WaitForConditionTests.cs
+++ b/Assets/Responsible/Tests/Runtime/WaitForConditionTests.cs
@@ -95,7 +95,7 @@ namespace Responsible.Tests.Runtime
 					"Should be canceled",
 					() => false,
 					_ => extraContextRequested = true)
-				.ThenRespondWith("Do nothing", Nop);
+				.ThenRespondWithAction("Do nothing", Nop);
 
 			// Never execute the optional responder, leading to the wait being canceled.
 			// But error out afterwards, to get a failure message.

--- a/Assets/Responsible/Tests/Runtime/WaitForLastTests.cs
+++ b/Assets/Responsible/Tests/Runtime/WaitForLastTests.cs
@@ -82,7 +82,7 @@ namespace Responsible.Tests.Runtime
 		[Test]
 		public void WaitForLast_ProducesCorrectState_WhenErrorEncountered()
 		{
-			var state = WaitForLast("My description", Observable.Throw<int>(new Exception()))
+			WaitForLast("My description", Observable.Throw<int>(new Exception()))
 				.ExpectWithinSeconds(1)
 				.ToObservable(this.Executor)
 				.Subscribe(Nop, this.StoreError);

--- a/Packages/Responsible/Runtime/Responsibly.WaitFor.cs
+++ b/Packages/Responsible/Runtime/Responsibly.WaitFor.cs
@@ -21,24 +21,12 @@ namespace Responsible
 	/// </remarks>
 	public static partial class Responsibly
 	{
-		[Pure]
-		public static ITestWaitCondition<TResult> WaitForConditionOn<TObject, TResult>(
-			string description,
-			Func<TObject> getObject,
-			Func<TObject, bool> condition,
-			Func<TObject, TResult> makeResult,
-			Action<StateStringBuilder> extraContext = null,
-			[CallerMemberName] string memberName = "",
-			[CallerFilePath] string sourceFilePath = "",
-			[CallerLineNumber] int sourceLineNumber = 0)
-			=> new PollingWaitCondition<TObject, TResult>(
-				description,
-				getObject,
-				condition,
-				makeResult,
-				extraContext,
-				new SourceContext(nameof(WaitForCondition), memberName, sourceFilePath, sourceLineNumber));
-
+		/// <summary>
+		/// Constructs a wait condition, which will call an object getter on every frame,
+		/// and check a condition on the returned object.
+		/// Will complete once the condition returns true,
+		/// returning the last value returned by the object provider.
+		/// </summary>
 		[Pure]
 		public static ITestWaitCondition<T> WaitForConditionOn<T>(
 			string description,
@@ -48,31 +36,17 @@ namespace Responsible
 			[CallerMemberName] string memberName = "",
 			[CallerFilePath] string sourceFilePath = "",
 			[CallerLineNumber] int sourceLineNumber = 0)
-			=> new PollingWaitCondition<T, T>(
+			=> new PollingWaitCondition<T>(
 				description,
 				getObject,
 				condition,
-				_ => _,
 				extraContext,
-				new SourceContext(nameof(WaitForCondition), memberName, sourceFilePath, sourceLineNumber));
+				new SourceContext(nameof(WaitForConditionOn), memberName, sourceFilePath, sourceLineNumber));
 
-		[Pure]
-		public static ITestWaitCondition<T> WaitForCondition<T>(
-			string description,
-			Func<bool> condition,
-			Func<T> makeResult,
-			Action<StateStringBuilder> extraContext = null,
-			[CallerMemberName] string memberName = "",
-			[CallerFilePath] string sourceFilePath = "",
-			[CallerLineNumber] int sourceLineNumber = 0)
-			=> new PollingWaitCondition<Unit, T>(
-				description,
-				() => Unit.Default,
-				_ => condition(),
-				_ => makeResult(),
-				extraContext,
-				new SourceContext(nameof(WaitForCondition), memberName, sourceFilePath, sourceLineNumber));
-
+		/// <summary>
+		/// Constructs a wait condition, which will poll a condition,
+		/// and complete once the condition returns true.
+		/// </summary>
 		[Pure]
 		public static ITestWaitCondition<Unit> WaitForCondition(
 			string description,
@@ -81,11 +55,10 @@ namespace Responsible
 			[CallerMemberName] string memberName = "",
 			[CallerFilePath] string sourceFilePath = "",
 			[CallerLineNumber] int sourceLineNumber = 0)
-			=> new PollingWaitCondition<Unit, Unit>(
+			=> new PollingWaitCondition<Unit>(
 				description,
 				() => Unit.Default,
 				_ => condition(),
-				_ => Unit.Default,
 				extraContext,
 				new SourceContext(nameof(WaitForCondition), memberName, sourceFilePath, sourceLineNumber));
 

--- a/Packages/Responsible/Runtime/Responsibly.WaitFor.cs
+++ b/Packages/Responsible/Runtime/Responsibly.WaitFor.cs
@@ -107,32 +107,50 @@ namespace Responsible
 				constraint,
 				new SourceContext(nameof(WaitForConstraint), memberName, sourceFilePath, sourceLineNumber));
 
+		/// <summary>
+		/// Construct a wait condition, which will start the provided coroutine when executed.
+		/// Will complete when the coroutine has terminated.
+		/// <seealso cref="WaitForCoroutineMethod"/>
+		/// </summary>
+		/// <remarks>
+		///	May be used with local functions and lambdas, as the description is manually provided.
+		/// </remarks>
+		/// <param name="description"></param>
+		/// <param name="startCoroutine"></param>
+		/// <param name="memberName"></param>
+		/// <param name="sourceFilePath"></param>
+		/// <param name="sourceLineNumber"></param>
+		/// <returns></returns>
 		[Pure]
 		public static ITestWaitCondition<Unit> WaitForCoroutine(
+			string description,
 			Func<IEnumerator> startCoroutine,
-			[CanBeNull] string description = null,
 			[CallerMemberName] string memberName = "",
 			[CallerFilePath] string sourceFilePath = "",
 			[CallerLineNumber] int sourceLineNumber = 0)
-		=> new CoroutineWaitCondition<Unit>(
+		=> new CoroutineWaitCondition(
 			description,
 			startCoroutine,
-			() => Unit.Default,
 			new SourceContext(nameof(WaitForCoroutine), memberName, sourceFilePath, sourceLineNumber));
 
+		/// <summary>
+		/// Construct a wait condition, which will start the provided coroutine when executed.
+		/// Will complete when the coroutine has terminated.
+		/// <seealso cref="WaitForCoroutine"/>
+		/// </summary>
+		/// <remarks>
+		/// If used with a lambda or local function, you will get a weird compiler-generated description.
+		/// </remarks>
 		[Pure]
-		public static ITestWaitCondition<T> WaitForCoroutine<T>(
-			Func<IEnumerator> startCoroutine,
-			Func<T> makeResult,
-			[CanBeNull] string description = null,
+		public static ITestWaitCondition<Unit> WaitForCoroutineMethod(
+			Func<IEnumerator> coroutineMethod,
 			[CallerMemberName] string memberName = "",
 			[CallerFilePath] string sourceFilePath = "",
 			[CallerLineNumber] int sourceLineNumber = 0)
-			=> new CoroutineWaitCondition<T>(
-				description,
-				startCoroutine,
-				makeResult,
-				new SourceContext(nameof(WaitForCoroutine), memberName, sourceFilePath, sourceLineNumber));
+			=> new CoroutineWaitCondition(
+				coroutineMethod.Method.Name,
+				coroutineMethod,
+				new SourceContext(nameof(WaitForCoroutineMethod), memberName, sourceFilePath, sourceLineNumber));
 
 		[Pure]
 		public static ITestInstruction<Unit> WaitForSeconds(

--- a/Packages/Responsible/Runtime/TestResponders/TestResponder.cs
+++ b/Packages/Responsible/Runtime/TestResponders/TestResponder.cs
@@ -1,5 +1,4 @@
 using System;
-using JetBrains.Annotations;
 using Responsible.Context;
 using Responsible.State;
 using UniRx;

--- a/Packages/Responsible/Runtime/TestWaitCondition.cs
+++ b/Packages/Responsible/Runtime/TestWaitCondition.cs
@@ -85,7 +85,7 @@ namespace Responsible
 		/// and then continue executing a synchronous action.
 		/// </summary>
 		[Pure]
-		public static ITestResponder<TResult> ThenRespondWith<TWait, TResult>(
+		public static ITestResponder<TResult> ThenRespondWithFunc<TWait, TResult>(
 			this ITestWaitCondition<TWait> condition,
 			string description,
 			Func<TWait, TResult> selector,
@@ -98,15 +98,15 @@ namespace Responsible
 				waitResult => new SynchronousTestInstruction<TResult>(
 					description,
 					() => selector(waitResult),
-					new SourceContext(nameof(ThenRespondWith), memberName, sourceFilePath, sourceLineNumber)),
-				new SourceContext(nameof(ThenRespondWith), memberName, sourceFilePath, sourceLineNumber));
+					new SourceContext(nameof(ThenRespondWithFunc), memberName, sourceFilePath, sourceLineNumber)),
+				new SourceContext(nameof(ThenRespondWithFunc), memberName, sourceFilePath, sourceLineNumber));
 
 		/// <summary>
 		/// Constructs a test responder, which will wait for the given condition,
 		/// and then continue executing a synchronous action.
 		/// </summary>
 		[Pure]
-		public static ITestResponder<Unit> ThenRespondWith<TWait>(
+		public static ITestResponder<Unit> ThenRespondWithAction<TWait>(
 			this ITestWaitCondition<TWait> condition,
 			string description,
 			Action<TWait> action,
@@ -119,8 +119,8 @@ namespace Responsible
 				waitResult => new SynchronousTestInstruction<Unit>(
 					description,
 					action.AsUnitFunc(waitResult),
-					new SourceContext(nameof(ThenRespondWith), memberName, sourceFilePath, sourceLineNumber)),
-				new SourceContext(nameof(ThenRespondWith), memberName, sourceFilePath, sourceLineNumber));
+					new SourceContext(nameof(ThenRespondWithAction), memberName, sourceFilePath, sourceLineNumber)),
+				new SourceContext(nameof(ThenRespondWithAction), memberName, sourceFilePath, sourceLineNumber));
 
 		/// <summary>
 		/// Converts a wait condition to an instruction, by enforcing a timeout on it.

--- a/Packages/Responsible/Runtime/TestWaitConditions/CoroutineWaitCondition.cs
+++ b/Packages/Responsible/Runtime/TestWaitConditions/CoroutineWaitCondition.cs
@@ -7,21 +7,19 @@ using UniRx;
 
 namespace Responsible.TestWaitConditions
 {
-	internal class CoroutineWaitCondition<T> : TestWaitConditionBase<T>
+	internal class CoroutineWaitCondition : TestWaitConditionBase<Unit>
 	{
 		public CoroutineWaitCondition(
-			[CanBeNull] string description,
+			string description,
 			Func<IEnumerator> startCoroutine,
-			Func<T> makeResult,
 			SourceContext sourceContext)
-			: base(() => new State(description, startCoroutine, makeResult, sourceContext))
+			: base(() => new State(description, startCoroutine, sourceContext))
 		{
 		}
 
-		private class State : TestOperationState<T>, IDiscreteWaitConditionState
+		private class State : TestOperationState<Unit>, IDiscreteWaitConditionState
 		{
 			private readonly Func<IEnumerator> startCoroutine;
-			private readonly Func<T> makeResult;
 
 			public string Description { get; }
 			public Action<StateStringBuilder> ExtraContext => null;
@@ -29,18 +27,15 @@ namespace Responsible.TestWaitConditions
 			public State(
 				[CanBeNull] string description,
 				Func<IEnumerator> startCoroutine,
-				Func<T> makeResult,
 				SourceContext sourceContext)
 				: base(sourceContext)
 			{
-				this.Description = $"{description ?? startCoroutine.Method.Name} (Coroutine)";
+				this.Description = $"{description} (Coroutine)";
 				this.startCoroutine = startCoroutine;
-				this.makeResult = makeResult;
 			}
 
-			protected override IObservable<T> ExecuteInner(RunContext runContext) => Observable
-				.FromCoroutine(this.startCoroutine)
-				.Select(_ => this.makeResult());
+			protected override IObservable<Unit> ExecuteInner(RunContext runContext) => Observable
+				.FromCoroutine(this.startCoroutine);
 
 			public override void BuildDescription(StateStringBuilder builder) => builder.AddWait(this);
 		}

--- a/Packages/Responsible/Runtime/TestWaitConditions/PollingWaitCondition.cs
+++ b/Packages/Responsible/Runtime/TestWaitConditions/PollingWaitCondition.cs
@@ -26,7 +26,7 @@ namespace Responsible.TestWaitConditions
 			private readonly Func<TCondition, TResult> makeResult;
 
 			public string Description { get; }
-			[CanBeNull] public Action<StateStringBuilder> ExtraContext { get; }
+			public Action<StateStringBuilder> ExtraContext { get; }
 
 			public State(
 				string description,

--- a/Packages/Responsible/Runtime/TestWaitConditions/PollingWaitCondition.cs
+++ b/Packages/Responsible/Runtime/TestWaitConditions/PollingWaitCondition.cs
@@ -6,33 +6,30 @@ using UniRx;
 
 namespace Responsible.TestWaitConditions
 {
-	internal class PollingWaitCondition<TCondition, TResult> : TestWaitConditionBase<TResult>
+	internal class PollingWaitCondition<T> : TestWaitConditionBase<T>
 	{
 		public PollingWaitCondition(
 			string description,
-			Func<TCondition> getConditionState,
-			Func<TCondition, bool> condition,
-			Func<TCondition, TResult> makeResult,
+			Func<T> getConditionState,
+			Func<T, bool> condition,
 			[CanBeNull] Action<StateStringBuilder> extraContext,
 			SourceContext sourceContext)
-			: base(() => new State(description, getConditionState, condition, makeResult, extraContext, sourceContext))
+			: base(() => new State(description, getConditionState, condition, extraContext, sourceContext))
 		{
 		}
 
-		private class State : TestOperationState<TResult>, IDiscreteWaitConditionState
+		private class State : TestOperationState<T>, IDiscreteWaitConditionState
 		{
-			private readonly Func<TCondition> getConditionState;
-			private readonly Func<TCondition, bool> condition;
-			private readonly Func<TCondition, TResult> makeResult;
+			private readonly Func<T> getConditionState;
+			private readonly Func<T, bool> condition;
 
 			public string Description { get; }
 			public Action<StateStringBuilder> ExtraContext { get; }
 
 			public State(
 				string description,
-				Func<TCondition> getConditionState,
-				Func<TCondition, bool> condition,
-				Func<TCondition, TResult> makeResult,
+				Func<T> getConditionState,
+				Func<T, bool> condition,
 				[CanBeNull] Action<StateStringBuilder> extraContext,
 				SourceContext sourceContext)
 				: base(sourceContext)
@@ -40,17 +37,15 @@ namespace Responsible.TestWaitConditions
 				this.Description = description;
 				this.getConditionState = getConditionState;
 				this.condition = condition;
-				this.makeResult = makeResult;
 				this.ExtraContext = extraContext;
 			}
 
-			protected override IObservable<TResult> ExecuteInner(RunContext runContext) => runContext
+			protected override IObservable<T> ExecuteInner(RunContext runContext) => runContext
 				.PollObservable
 				.StartWith(Unit.Default) // Allow immediate completion
 				.Select(_ => this.getConditionState())
 				.Where(this.condition)
-				.Take(1)
-				.Select(this.makeResult);
+				.Take(1);
 
 			public override void BuildDescription(StateStringBuilder builder) => builder.AddWait(this);
 		}

--- a/Packages/Responsible/Samples~/ResponsibleGame/PlayModeTests/SystemTest.cs
+++ b/Packages/Responsible/Samples~/ResponsibleGame/PlayModeTests/SystemTest.cs
@@ -65,8 +65,7 @@ namespace ResponsibleGame.PlayModeTests
 		protected ITestResponder<Unit> TriggerHit(bool shouldHit) => WaitForMainComponents()
 			.AndThen(components => WaitForCondition(
 				$"Player object is within target area: {shouldHit}",
-				() => PlayerIsOnTarget(components) == shouldHit,
-				() => components))
+				() => PlayerIsOnTarget(components) == shouldHit))
 			.ThenRespondWith($"Trigger {(shouldHit ? "hit" : "miss")}", this.MockTriggerInput());
 
 		protected ITestInstruction<Unit> MockTriggerInput() =>

--- a/Packages/Responsible/package.json
+++ b/Packages/Responsible/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.beatwaves.responsible",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "displayName": "Responsible",
   "description": "Reactive asynchronous automated testing utility to enhance the Unity Test Runner.\nProvides a framework for constructing asynchronous\n- wait conditions,\n- test instructions,\n- and responders, which execute an instruction when a condition is met\nAlso includes utilities for combining and chaining all of the above.",
   "unity": "2018.4",

--- a/Responsible.sln.DotSettings
+++ b/Responsible.sln.DotSettings
@@ -33,6 +33,7 @@
 	<s:Boolean x:Key="/Default/Environment/AutoImport2/=CSHARP/BlackLists/=Castle_002E_002A/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/AutoImport2/=CSHARP/BlackLists/=UnityScript_002E_002A/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EFeature_002EServices_002EImportType_002EBlackList_002EAutoImportSettingsMigrate/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EFeature_002EServices_002EImportType_002EBlockList_002EAutoImportSettingsMigrate/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
Simplify the public API by reducing the number of overloads used. This should make auto-completion and compiler errors more friendly. Only a few overloads remain, which should be pretty clear.

**Will require bumping version to 2.0! to conform with semver!**

* Removes `WaitForCondition`, `WaitForConditionOn` and `WaitForCoroutine` overrides, which make a result: `Select` can be used instead.
* Synchronous `ThenRespondWith` overrides renamed to `ThenRespondWithFunc` and `ThenRespondWithAction`
* Splits `WaitForCoroutine` to two versions:
    * `WaitForCoroutine`: takes `description` as the first argument, as is the convention.
    * `WaitForCoroutineMethod`: uses the method name as description