### PR TITLE
Fix Unity coverage measuring

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,9 +43,11 @@ jobs:
         with:
           projectPath: ResponsibleUnity
           unityVersion: ${{ matrix.unityVersion }}
+          # TaskExtensions is excluded from coverage, because Unity is having a hard time with some attributes.
+          # It's covered in .NET standard, so shouldn't be a problem excluding it here...
           customParameters: -enableCodeCoverage
             -coverageResultsPath "../artifacts/CodeCoverage/"
-            -coverageOptions assemblyFilters:+Responsible,+Responsible.Editor
+            -coverageOptions assemblyFilters:+Responsible,+Responsible.Editor;pathFilters:-*TaskExtensions.cs*
             -debugCodeOptimization
             -nographics
             -disable-assembly-updater

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,11 +43,10 @@ jobs:
         with:
           projectPath: ResponsibleUnity
           unityVersion: ${{ matrix.unityVersion }}
-          # TaskExtensions is excluded from coverage, because Unity is having a hard time with some attributes.
-          # It's covered in .NET standard, so shouldn't be a problem excluding it here...
           customParameters: -enableCodeCoverage
             -coverageResultsPath "../artifacts/CodeCoverage/"
-            -coverageOptions assemblyFilters:+Responsible,+Responsible.Editor;pathFilters:-*TaskExtensions.cs*
+            -coverageOptions assemblyFilters:+Responsible,+Responsible.Editor
+            -debugCodeOptimization
             -nographics
             -disable-assembly-updater
       


### PR DESCRIPTION
...by passing the right CLI arguments.

Also check if the exclude is still needed with 2020.3