### PR TITLE
Fix ReSharper paths

### DIFF
--- a/ResponsibleUnity/Assets/EditorSetup/ContinuousIntegration.cs
+++ b/ResponsibleUnity/Assets/EditorSetup/ContinuousIntegration.cs
@@ -69,6 +69,7 @@ namespace Responsible.EditorSetup
                 command: "inspectcode",
                 Quote(solution),
                 $"-o={Quote(ResharperResults)}",
+                "-a", // Use absolute paths to make this work better in GitHub
                 "-s=WARNING");
 
             File.WriteAllText(ResharperStdout, stdout);


### PR DESCRIPTION
When the Unity project got moved, these broke. Let's see if absolute paths work in Actions: the docs were very unclear about it.