### PR TITLE
Fix error handling in ContinueWith and AndThen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fix error handling in `ContinueWith` and `AndThen` to publish the correct exception.
+  This was previously causing an internal exception to be published instead under certain conditions.
+
 ## [4.1.0] - 2021-05-13
 
 ### Fixed

--- a/Tests/AndThenTests.cs
+++ b/Tests/AndThenTests.cs
@@ -116,7 +116,7 @@ namespace Responsible.Tests
 		{
 			var expectedException = new Exception("Test exception");
 			var task = ImmediateTrue
-				.AndThen<bool, object>(_ => WaitForCondition(
+				.AndThen(_ => WaitForCondition(
 					"throw",
 					() => throw expectedException))
 				.ExpectWithinSeconds(1)

--- a/com.beatwaves.responsible/Runtime/State/Continuation.cs
+++ b/com.beatwaves.responsible/Runtime/State/Continuation.cs
@@ -33,8 +33,6 @@ namespace Responsible.State
 			try
 			{
 				this.executionState = this.makeContinuation(source);
-				this.creationStatus = new TestOperationStatus.Completed(this.creationStatus);
-				return await this.executionState.Execute(runContext, cancellationToken);
 			}
 			catch (Exception e)
 			{
@@ -42,6 +40,9 @@ namespace Responsible.State
 					new TestOperationStatus.Failed(this.creationStatus, e, runContext.SourceContext);
 				throw;
 			}
+
+			this.creationStatus = new TestOperationStatus.Completed(this.creationStatus);
+			return await this.executionState.Execute(runContext, cancellationToken);
 		}
 	}
 }


### PR DESCRIPTION
We were trying to transition the continuation creation status from completed to failed, which tripped an internal assertion, and published the wrong error.