### PR TITLE
Support for BDD-style tests (no DSL, just C#)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Changes in state strings or Unity Editor utilities are **not** considered breaking changes.
 
+Everything in the `Responsible.Bdd` namespace is currently considered experimental,
+and thus not under semantic versioning.
+
 ## [Unreleased]
 
 ### Added
 - New `GroupedAs` operator to allow more control over the state strings of compound operations.
+- Experimental: New BDD-style keywords to build scenarios.
 
 ## [4.2.0] - 2021-10-13
 

--- a/Tests/BddTests.cs
+++ b/Tests/BddTests.cs
@@ -1,4 +1,9 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Runtime.CompilerServices;
 using NUnit.Framework;
+using Responsible.Bdd;
 using Responsible.Tests.Utilities;
 using static Responsible.Responsibly;
 using static Responsible.Bdd.Keywords;
@@ -21,8 +26,7 @@ namespace Responsible.Tests
 			this.whenExecuted = false;
 			this.thenExecuted = false;
 
-			this.scenario = Scenario(
-				"Test scenario",
+			this.scenario = Scenario("Test scenario").WithSteps(
 				Given(
 					"given",
 					Do("given inner", () => this.givenExecuted = true)),
@@ -62,5 +66,50 @@ namespace Responsible.Tests
 				.Details("  ").NotStarted("Then then")
 				.Details("    ").NotStarted("then inner");
 		}
+
+		// The keywords below are considered omissible from the instruction stacks, they only show up in the
+		// operation states.
+		[TestCase("Given")]
+		[TestCase("And")]
+		[TestCase("When")]
+		[TestCase("Then")]
+		[SuppressMessage("ReSharper", "PossibleNullReferenceException")]
+		public void InstructionStack_DoesNotContainKeyword(string methodName)
+		{
+			var throwInstruction = Do("Throw", () => throw new Exception());
+			var method = typeof(Keywords)
+				.GetMethod(methodName, BindingFlags.Public | BindingFlags.Static)
+				.MakeGenericMethod(typeof(object));
+			var instruction = (ITestInstruction<object>)method.Invoke(
+				null,
+				new object[] { methodName, throwInstruction });
+			var state = instruction.CreateState();
+
+			state.ToTask(this.Executor);
+
+			StringAssert.DoesNotContain($"[{methodName}]", state.ToString());
+		}
+
+		// Partially for implementation detail reasons, and partially because it's nice to at least see
+		// the top-level scenario in operation stacks, make sure the scenario location is properly recorded.
+		[Test]
+		public void InstructionStack_DoesContainScenarioKeywordAndLocation()
+		{
+			var failingScenario = Scenario("Failing scenario").WithSteps(
+				Do("NOP", () => { }),
+				Do("Throw", () => throw new Exception("Test exception")));
+			var state = failingScenario.CreateState();
+
+			state.ToTask(this.Executor);
+
+			StringAssert.Contains(
+				$"[{nameof(Scenario)}] {GetCallerDetails()}",
+				state.ToString());
+		}
+
+		private static string GetCallerDetails(
+			[CallerMemberName] string member = null,
+			[CallerFilePath] string file = null) =>
+			$"{member} (at {file}";
 	}
 }

--- a/Tests/BddTests.cs
+++ b/Tests/BddTests.cs
@@ -78,8 +78,7 @@ namespace Responsible.Tests
 		{
 			var throwInstruction = Do("Throw", () => throw new Exception());
 			var method = typeof(Keywords)
-				.GetMethod(methodName, BindingFlags.Public | BindingFlags.Static)
-				.MakeGenericMethod(typeof(object));
+				.GetMethod(methodName, BindingFlags.Public | BindingFlags.Static);
 			var instruction = (ITestInstruction<object>)method.Invoke(
 				null,
 				new object[] { methodName, throwInstruction });

--- a/Tests/BddTests.cs
+++ b/Tests/BddTests.cs
@@ -96,8 +96,8 @@ namespace Responsible.Tests
 		public void InstructionStack_DoesContainScenarioKeywordAndLocation()
 		{
 			var failingScenario = Scenario("Failing scenario").WithSteps(
-				Do("NOP", () => { }),
-				Do("Throw", () => throw new Exception("Test exception")));
+				Given("nothing", Do("NOP", () => { })),
+				Then("throw", Do("Throw", () => throw new Exception("Test exception"))));
 			var state = failingScenario.CreateState();
 
 			state.ToTask(this.Executor);

--- a/Tests/BddTests.cs
+++ b/Tests/BddTests.cs
@@ -1,0 +1,66 @@
+using NUnit.Framework;
+using Responsible.Tests.Utilities;
+using static Responsible.Responsibly;
+using static Responsible.Bdd.Keywords;
+
+namespace Responsible.Tests
+{
+	public class BddTests : ResponsibleTestBase
+	{
+		private bool givenExecuted;
+		private bool andExecuted;
+		private bool whenExecuted;
+		private bool thenExecuted;
+		private ITestInstruction<object> scenario;
+
+		[SetUp]
+		public void SetUp()
+		{
+			this.givenExecuted = false;
+			this.andExecuted = false;
+			this.whenExecuted = false;
+			this.thenExecuted = false;
+
+			this.scenario = Scenario(
+				"Test scenario",
+				Given(
+					"given",
+					Do("given inner", () => this.givenExecuted = true)),
+				And(
+					"and",
+					Do("and inner", () => this.andExecuted = true)),
+				When(
+					"when",
+					Do("when inner", () => this.whenExecuted = true)),
+				Then(
+					"then",
+					Do("then inner", () => this.thenExecuted = true)));
+		}
+
+		[Test]
+		public void Scenario_ExecutesAllSteps()
+		{
+			this.scenario.ToTask(this.Executor);
+			Assert.AreEqual(
+				(true, true, true, true),
+				(this.givenExecuted, this.andExecuted, this.whenExecuted, this.thenExecuted));
+		}
+
+		[Test]
+		public void StateString_ContainsExpectedContent()
+		{
+			var stateString = this.scenario.CreateState().ToString();
+
+			StateAssert.StringContainsInOrder(stateString)
+				.NotStarted("Scenario: Test scenario")
+				.Details("  ").NotStarted("Given given")
+				.Details("    ").NotStarted("given inner")
+				.Details("  ").NotStarted("And and")
+				.Details("    ").NotStarted("and inner")
+				.Details("  ").NotStarted("When when")
+				.Details("    ").NotStarted("when inner")
+				.Details("  ").NotStarted("Then then")
+				.Details("    ").NotStarted("then inner");
+		}
+	}
+}

--- a/Tests/BddTests.cs.meta
+++ b/Tests/BddTests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 7bd2fead209a4233bc462b3cb055a383
+timeCreated: 1649516028

--- a/Tests/GroupedAsTests.cs
+++ b/Tests/GroupedAsTests.cs
@@ -1,3 +1,4 @@
+using System;
 using NUnit.Framework;
 using Responsible.Tests.Utilities;
 using static Responsible.Responsibly;
@@ -46,6 +47,23 @@ namespace Responsible.Tests
 				.Completed("Wrapper")
 				.Details("  ")
 				.Completed("Execute");
+		}
+
+		[Test]
+		public void OperationStack_DoesNotContainGroupedAs()
+		{
+			var state = Responsibly
+				.Do(
+					"Throw",
+					() => throw new Exception("Test exception"))
+				.GroupedAs("Test group")
+				.CreateState();
+
+			state.ToTask(this.Executor);
+
+			StringAssert.DoesNotContain(
+				$"[{nameof(TestInstruction.GroupedAs)}]",
+				state.ToString());
 		}
 	}
 }

--- a/com.beatwaves.responsible/Runtime/Bdd.meta
+++ b/com.beatwaves.responsible/Runtime/Bdd.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 5c1e09d741804290bdce651ba6b7e5b8
+timeCreated: 1649515553

--- a/com.beatwaves.responsible/Runtime/Bdd/BddStep.cs
+++ b/com.beatwaves.responsible/Runtime/Bdd/BddStep.cs
@@ -1,0 +1,16 @@
+using Responsible.State;
+
+namespace Responsible.Bdd
+{
+	internal class BddStep<T> : IBddStep<T>
+	{
+		private readonly ITestInstruction<T> instruction;
+
+		public BddStep(ITestInstruction<T> instruction)
+		{
+			this.instruction = instruction;
+		}
+
+		public ITestOperationState<T> CreateState() => this.instruction.CreateState();
+	}
+}

--- a/com.beatwaves.responsible/Runtime/Bdd/BddStep.cs
+++ b/com.beatwaves.responsible/Runtime/Bdd/BddStep.cs
@@ -2,15 +2,15 @@ using Responsible.State;
 
 namespace Responsible.Bdd
 {
-	internal class BddStep<T> : IBddStep<T>
+	internal class BddStep : IBddStep
 	{
-		private readonly ITestInstruction<T> instruction;
+		private readonly ITestInstruction<object> instruction;
 
-		public BddStep(ITestInstruction<T> instruction)
+		public BddStep(ITestInstruction<object> instruction)
 		{
 			this.instruction = instruction;
 		}
 
-		public ITestOperationState<T> CreateState() => this.instruction.CreateState();
+		public ITestOperationState<object> CreateState() => this.instruction.CreateState();
 	}
 }

--- a/com.beatwaves.responsible/Runtime/Bdd/BddStep.cs.meta
+++ b/com.beatwaves.responsible/Runtime/Bdd/BddStep.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 525d4577aac94c5e91ca50a8b372bfd0
+timeCreated: 1649520706

--- a/com.beatwaves.responsible/Runtime/Bdd/IBddStep.cs
+++ b/com.beatwaves.responsible/Runtime/Bdd/IBddStep.cs
@@ -6,8 +6,7 @@ namespace Responsible.Bdd
 	/// are properly wrapped in other BDD-keywords.
 	/// Functionally no different from <see cref="ITestInstruction{T}"/>.
 	/// </summary>
-	/// <typeparam name="T">Result type of the test instruction.</typeparam>
-	public interface IBddStep<out T> : ITestInstruction<T>
+	public interface IBddStep : ITestInstruction<object>
 	{
 	}
 }

--- a/com.beatwaves.responsible/Runtime/Bdd/IBddStep.cs
+++ b/com.beatwaves.responsible/Runtime/Bdd/IBddStep.cs
@@ -1,0 +1,13 @@
+namespace Responsible.Bdd
+{
+	/// <summary>
+	/// Tag interface for BDD-style test instructions.
+	/// This exists only to be able to enforce that all instructions used in a scenario
+	/// are properly wrapped in other BDD-keywords.
+	/// Functionally no different from <see cref="ITestInstruction{T}"/>.
+	/// </summary>
+	/// <typeparam name="T">Result type of the test instruction.</typeparam>
+	public interface IBddStep<out T> : ITestInstruction<T>
+	{
+	}
+}

--- a/com.beatwaves.responsible/Runtime/Bdd/IBddStep.cs.meta
+++ b/com.beatwaves.responsible/Runtime/Bdd/IBddStep.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: bfbb561e3ec24e84ab1c643667b2a950
+timeCreated: 1649520585

--- a/com.beatwaves.responsible/Runtime/Bdd/Keywords.cs
+++ b/com.beatwaves.responsible/Runtime/Bdd/Keywords.cs
@@ -1,13 +1,15 @@
+using System.Runtime.CompilerServices;
+
 namespace Responsible.Bdd
 {
 	public static class Keywords
 	{
-		// TODO: Source context?
-
-		public static ITestInstruction<object> Scenario(
+		public static ScenarioBuilder Scenario(
 			string description,
-			params ITestInstruction<object>[] steps) =>
-			steps.Sequence().GroupedAs($"Scenario: {description}");
+			[CallerMemberName] string memberName = "",
+			[CallerFilePath] string sourceFilePath = "",
+			[CallerLineNumber] int sourceLineNumber = 0) =>
+			new ScenarioBuilder(description, memberName, sourceFilePath, sourceLineNumber);
 
 		public static ITestInstruction<T> Given<T>(
 			string description,

--- a/com.beatwaves.responsible/Runtime/Bdd/Keywords.cs
+++ b/com.beatwaves.responsible/Runtime/Bdd/Keywords.cs
@@ -3,6 +3,7 @@ using System.Runtime.CompilerServices;
 namespace Responsible.Bdd
 {
 	/// <summary>
+	/// EXPERIMENTAL:
 	/// Keywords for building BDD-style tests for clearer source code and state strings.
 	/// Helps in building tests with consistent style.
 	/// </summary>

--- a/com.beatwaves.responsible/Runtime/Bdd/Keywords.cs
+++ b/com.beatwaves.responsible/Runtime/Bdd/Keywords.cs
@@ -25,37 +25,37 @@ namespace Responsible.Bdd
 		/// <summary>
 		/// Creates a step that describes the initial context of a test.
 		/// </summary>
-		/// <inheritdoc cref="Docs.Inherit.BddKeyword{T}"/>
-		public static IBddStep<T> Given<T>(
+		/// <inheritdoc cref="Docs.Inherit.BddKeyword"/>
+		public static IBddStep Given(
 			string description,
-			ITestInstruction<T> instruction) =>
-			new BddStep<T>(instruction.GroupedAs($"Given {description}"));
+			ITestInstruction<object> instruction) =>
+			new BddStep(instruction.GroupedAs($"Given {description}"));
 
 		/// <summary>
 		/// Creates a step that describes additional initial context of a test.
 		/// </summary>
-		/// <inheritdoc cref="Docs.Inherit.BddKeyword{T}"/>
-		public static IBddStep<T> And<T>(
+		/// <inheritdoc cref="Docs.Inherit.BddKeyword"/>
+		public static IBddStep And(
 			string description,
-			ITestInstruction<T> instruction) =>
-			new BddStep<T>(instruction.GroupedAs($"And {description}"));
+			ITestInstruction<object> instruction) =>
+			new BddStep(instruction.GroupedAs($"And {description}"));
 
 		/// <summary>
 		/// Creates a step that describes an event or action in a test.
 		/// </summary>
-		/// <inheritdoc cref="Docs.Inherit.BddKeyword{T}"/>
-		public static IBddStep<T> When<T>(
+		/// <inheritdoc cref="Docs.Inherit.BddKeyword"/>
+		public static IBddStep When(
 			string description,
-			ITestInstruction<T> instruction) =>
-			new BddStep<T>(instruction.GroupedAs($"When {description}"));
+			ITestInstruction<object> instruction) =>
+			new BddStep(instruction.GroupedAs($"When {description}"));
 
 		/// <summary>
 		/// Creates a step that describes an expected outcome of a test.
 		/// </summary>
-		/// <inheritdoc cref="Docs.Inherit.BddKeyword{T}"/>
-		public static IBddStep<T> Then<T>(
+		/// <inheritdoc cref="Docs.Inherit.BddKeyword"/>
+		public static IBddStep Then(
 			string description,
-			ITestInstruction<T> instruction) =>
-			new BddStep<T>(instruction.GroupedAs($"Then {description}"));
+			ITestInstruction<object> instruction) =>
+			new BddStep(instruction.GroupedAs($"Then {description}"));
 	}
 }

--- a/com.beatwaves.responsible/Runtime/Bdd/Keywords.cs
+++ b/com.beatwaves.responsible/Runtime/Bdd/Keywords.cs
@@ -2,8 +2,18 @@ using System.Runtime.CompilerServices;
 
 namespace Responsible.Bdd
 {
+	/// <summary>
+	/// Keywords for building BDD-style tests for clearer source code and state strings.
+	/// Helps in building tests with consistent style.
+	/// </summary>
 	public static class Keywords
 	{
+		/// <summary>
+		/// Starts building a new BDD-style scenario.
+		/// </summary>
+		/// <param name="description">Description of the scenario</param>
+		/// <inheritdoc cref="Docs.Inherit.CallerMember{T}"/>
+		/// <returns>A scenario builder with the given description.</returns>
 		public static ScenarioBuilder Scenario(
 			string description,
 			[CallerMemberName] string memberName = "",
@@ -11,24 +21,40 @@ namespace Responsible.Bdd
 			[CallerLineNumber] int sourceLineNumber = 0) =>
 			new ScenarioBuilder(description, memberName, sourceFilePath, sourceLineNumber);
 
-		public static ITestInstruction<T> Given<T>(
+		/// <summary>
+		/// Creates a step that describes the initial context of a test.
+		/// </summary>
+		/// <inheritdoc cref="Docs.Inherit.BddKeyword{T}"/>
+		public static IBddStep<T> Given<T>(
 			string description,
 			ITestInstruction<T> instruction) =>
-			instruction.GroupedAs($"Given {description}");
+			new BddStep<T>(instruction.GroupedAs($"Given {description}"));
 
-		public static ITestInstruction<T> And<T>(
+		/// <summary>
+		/// Creates a step that describes additional initial context of a test.
+		/// </summary>
+		/// <inheritdoc cref="Docs.Inherit.BddKeyword{T}"/>
+		public static IBddStep<T> And<T>(
 			string description,
 			ITestInstruction<T> instruction) =>
-			instruction.GroupedAs($"And {description}");
+			new BddStep<T>(instruction.GroupedAs($"And {description}"));
 
-		public static ITestInstruction<T> When<T>(
+		/// <summary>
+		/// Creates a step that describes an event or action in a test.
+		/// </summary>
+		/// <inheritdoc cref="Docs.Inherit.BddKeyword{T}"/>
+		public static IBddStep<T> When<T>(
 			string description,
 			ITestInstruction<T> instruction) =>
-			instruction.GroupedAs($"When {description}");
+			new BddStep<T>(instruction.GroupedAs($"When {description}"));
 
-		public static ITestInstruction<T> Then<T>(
+		/// <summary>
+		/// Creates a step that describes an expected outcome of a test.
+		/// </summary>
+		/// <inheritdoc cref="Docs.Inherit.BddKeyword{T}"/>
+		public static IBddStep<T> Then<T>(
 			string description,
 			ITestInstruction<T> instruction) =>
-			instruction.GroupedAs($"Then {description}");
+			new BddStep<T>(instruction.GroupedAs($"Then {description}"));
 	}
 }

--- a/com.beatwaves.responsible/Runtime/Bdd/Keywords.cs
+++ b/com.beatwaves.responsible/Runtime/Bdd/Keywords.cs
@@ -1,0 +1,32 @@
+namespace Responsible.Bdd
+{
+	public static class Keywords
+	{
+		// TODO: Source context?
+
+		public static ITestInstruction<object> Scenario(
+			string description,
+			params ITestInstruction<object>[] steps) =>
+			steps.Sequence().GroupedAs($"Scenario: {description}");
+
+		public static ITestInstruction<T> Given<T>(
+			string description,
+			ITestInstruction<T> instruction) =>
+			instruction.GroupedAs($"Given {description}");
+
+		public static ITestInstruction<T> And<T>(
+			string description,
+			ITestInstruction<T> instruction) =>
+			instruction.GroupedAs($"And {description}");
+
+		public static ITestInstruction<T> When<T>(
+			string description,
+			ITestInstruction<T> instruction) =>
+			instruction.GroupedAs($"When {description}");
+
+		public static ITestInstruction<T> Then<T>(
+			string description,
+			ITestInstruction<T> instruction) =>
+			instruction.GroupedAs($"Then {description}");
+	}
+}

--- a/com.beatwaves.responsible/Runtime/Bdd/Keywords.cs.meta
+++ b/com.beatwaves.responsible/Runtime/Bdd/Keywords.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 8595755ae5bd43759661466f720ed492
+timeCreated: 1649515692

--- a/com.beatwaves.responsible/Runtime/Bdd/ScenarioBuilder.cs
+++ b/com.beatwaves.responsible/Runtime/Bdd/ScenarioBuilder.cs
@@ -1,0 +1,31 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Contracts;
+
+namespace Responsible.Bdd
+{
+	/// <summary>
+	/// Helper class to build scenarios with proper source context.
+	/// </summary>
+	public sealed class ScenarioBuilder
+	{
+		private readonly string description;
+		private readonly string memberName;
+		private readonly string sourceFilePath;
+		private readonly int sourceLineNumber;
+
+		internal ScenarioBuilder(string description, string memberName, string sourceFilePath, int sourceLineNumber)
+		{
+			this.description = description;
+			this.memberName = memberName;
+			this.sourceFilePath = sourceFilePath;
+			this.sourceLineNumber = sourceLineNumber;
+		}
+
+
+		[Pure]
+		[SuppressMessage("ReSharper", "ExplicitCallerInfoArgument")]
+		public ITestInstruction<object> WithSteps(params ITestInstruction<object>[] steps) => steps
+			.Sequence(this.memberName, this.sourceFilePath, this.sourceLineNumber, nameof(Keywords.Scenario))
+			.GroupedAs($"Scenario: {this.description}");
+	}
+}

--- a/com.beatwaves.responsible/Runtime/Bdd/ScenarioBuilder.cs
+++ b/com.beatwaves.responsible/Runtime/Bdd/ScenarioBuilder.cs
@@ -22,9 +22,14 @@ namespace Responsible.Bdd
 		}
 
 
+		/// <summary>
+		/// Builds a test instruction for the scenario from the given steps.
+		/// </summary>
+		/// <param name="steps">Steps to execute as part of the scenario.</param>
+		/// <returns>A test instruction which will execute the scenario.</returns>
 		[Pure]
 		[SuppressMessage("ReSharper", "ExplicitCallerInfoArgument")]
-		public ITestInstruction<object> WithSteps(params ITestInstruction<object>[] steps) => steps
+		public ITestInstruction<object> WithSteps(params IBddStep<object>[] steps) => steps
 			.Sequence(this.memberName, this.sourceFilePath, this.sourceLineNumber, nameof(Keywords.Scenario))
 			.GroupedAs($"Scenario: {this.description}");
 	}

--- a/com.beatwaves.responsible/Runtime/Bdd/ScenarioBuilder.cs
+++ b/com.beatwaves.responsible/Runtime/Bdd/ScenarioBuilder.cs
@@ -29,7 +29,7 @@ namespace Responsible.Bdd
 		/// <returns>A test instruction which will execute the scenario.</returns>
 		[Pure]
 		[SuppressMessage("ReSharper", "ExplicitCallerInfoArgument")]
-		public ITestInstruction<object> WithSteps(params IBddStep<object>[] steps) => steps
+		public ITestInstruction<object> WithSteps(params IBddStep[] steps) => steps
 			.Sequence(this.memberName, this.sourceFilePath, this.sourceLineNumber, nameof(Keywords.Scenario))
 			.GroupedAs($"Scenario: {this.description}");
 	}

--- a/com.beatwaves.responsible/Runtime/Bdd/ScenarioBuilder.cs.meta
+++ b/com.beatwaves.responsible/Runtime/Bdd/ScenarioBuilder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 656a9063d8094a759b61ce86e95b795e
+timeCreated: 1649519139

--- a/com.beatwaves.responsible/Runtime/Docs/Inherit.cs
+++ b/com.beatwaves.responsible/Runtime/Docs/Inherit.cs
@@ -155,5 +155,13 @@ namespace Responsible.Docs
 			int sourceLineNumber = 0)
 		{
 		}
+
+		/// <param name="description">Description of the step.</param>
+		/// <param name="instruction">Instruction to execute in this step.</param>
+		/// <typeparam name="T">Return type of the instruction in this step.</typeparam>
+		/// <returns>The given instruction as a BDD test step.</returns>
+		public abstract Bdd.IBddStep<T> BddKeyword<T>(
+			string description,
+			ITestInstruction<T> instruction);
 	}
 }

--- a/com.beatwaves.responsible/Runtime/Docs/Inherit.cs
+++ b/com.beatwaves.responsible/Runtime/Docs/Inherit.cs
@@ -158,10 +158,9 @@ namespace Responsible.Docs
 
 		/// <param name="description">Description of the step.</param>
 		/// <param name="instruction">Instruction to execute in this step.</param>
-		/// <typeparam name="T">Return type of the instruction in this step.</typeparam>
 		/// <returns>The given instruction as a BDD test step.</returns>
-		public abstract Bdd.IBddStep<T> BddKeyword<T>(
+		public abstract Bdd.IBddStep BddKeyword(
 			string description,
-			ITestInstruction<T> instruction);
+			ITestInstruction<object> instruction);
 	}
 }

--- a/com.beatwaves.responsible/Runtime/TestInstruction.cs
+++ b/com.beatwaves.responsible/Runtime/TestInstruction.cs
@@ -50,13 +50,14 @@ namespace Responsible
 			this IEnumerable<ITestInstruction<object>> instructions,
 			[CallerMemberName] string memberName = "",
 			[CallerFilePath] string sourceFilePath = "",
-			[CallerLineNumber] int sourceLineNumber = 0) =>
+			[CallerLineNumber] int sourceLineNumber = 0,
+			string operationName = nameof(Sequence)) =>
 			instructions.Aggregate((sequencedInstructions, nextInstruction) =>
 				new SequencedTestInstruction<object, object>(
 					sequencedInstructions,
 					nextInstruction,
 					new SourceContext(
-						nameof(Sequence), memberName, sourceFilePath, sourceLineNumber, isCollapsible: true)));
+						operationName, memberName, sourceFilePath, sourceLineNumber, isCollapsible: true)));
 
 		/// <summary>
 		/// Constructs a test instruction,

--- a/com.beatwaves.responsible/Samples~/ResponsibleGame/PlayModeTests/BddStyleTests.cs
+++ b/com.beatwaves.responsible/Samples~/ResponsibleGame/PlayModeTests/BddStyleTests.cs
@@ -1,0 +1,36 @@
+using System.Collections;
+using System.Linq;
+using NUnit.Framework;
+using Responsible;
+using UnityEngine.TestTools;
+using static Responsible.Bdd.Keywords;
+using static Responsible.Responsibly;
+
+namespace ResponsibleGame.PlayModeTests
+{
+	// Example of BDD-style tests
+	public class BddStyleTests : SystemTest
+	{
+		[UnityTest]
+		public IEnumerator TriggerKey_Restarts_AfterFailing()
+		{
+			var miss = this
+				.TriggerHit(false)
+				.ExpectWithinSeconds(2)
+				.ContinueWith(WaitForFrames(1));
+
+			var fail = Enumerable.Repeat(miss, Status.StartingLives).Sequence();
+
+			var assertRestarted = Do(
+				"Assert restarted",
+				() => Assert.IsTrue(ExpectStatusInstance().IsAlive));
+
+			return Scenario("The game should be restartable by pressing the trigger key")
+				.WithSteps(
+					Given("the player has failed", fail),
+					When("the user presses the trigger key", this.MockTriggerInput()),
+					Then("the game should be restarted", assertRestarted))
+				.ToYieldInstruction(this.TestInstructionExecutor);
+		}
+	}
+}

--- a/com.beatwaves.responsible/Samples~/ResponsibleGame/PlayModeTests/BddStyleTests.cs.meta
+++ b/com.beatwaves.responsible/Samples~/ResponsibleGame/PlayModeTests/BddStyleTests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 2872a4f60856403a91a5133927c7fa43
+timeCreated: 1649521833


### PR DESCRIPTION
Mostly thinking of test readability (both source code and status output) and consistency.

With the given example code
```
return Scenario("The game should be restartable by pressing the trigger key")
    .WithSteps(
        Given("the player has failed", fail),
        When("the user presses the trigger key", this.MockTriggerInput()),
        Then("the game should be restarted", assertRestarted))
    .ToYieldInstruction(this.TestInstructionExecutor);
```

here's a status snapshot from the middle of execution:
```
[.] Scenario: The game should be restartable by pressing the trigger key (Started 0.14 s ≈ 10 frames ago)
  [.] Given the player has failed (Started 0.14 s ≈ 10 frames ago)
    [✓] Trigger miss CONDITION EXPECTED WITHIN 2.00 s (Completed in 0.11 s ≈ 8 frames)
    [✓] WAIT FOR 1 FRAME(S) (Completed in 0.02 s ≈ 2 frames)
    [✓] Trigger miss CONDITION EXPECTED WITHIN 2.00 s (Completed in 0.00 s ≈ 0 frames)
    [.] WAIT FOR 1 FRAME(S) (Started 0.01 s ≈ 0 frames ago)
    [ ] Trigger miss CONDITION EXPECTED WITHIN 2.00 s
    [ ] WAIT FOR 1 FRAME(S)
  [ ] When the user presses the trigger key
    [ ] Mock trigger input
  [ ] Then the game should be restarted
    [ ] Assert restarted
```