### PR TITLE
ResponsibleGherkin CLI

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,7 @@ trim_trailing_whitespace = true
 charset = utf-8
 indent_style = tab
 indent_size = 4
+
+[{*.received.txt,*.verified.txt}]
+insert_final_newline = false
+trim_trailing_whitespace = false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and thus not under semantic versioning.
 ### Added
 - New `GroupedAs` operator to allow more control over the state strings of compound operations.
 - Experimental: New BDD-style keywords to build scenarios.
+- Experimental: ResponsibleGherkin dotnet tool to convert Gherkin feature specifications into Responsible test stubs.
+  Versioning of this tool is still to be figured out.
 
 ## [4.2.0] - 2021-10-13
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
         <MSBuildProjectExtensionsPath>.obj</MSBuildProjectExtensionsPath>
 
         <!-- For the same reasons as above, exclude these Unity files from standard projects -->
-        <DefaultItemExcludes>$(DefaultItemExcludes);**\*.meta;package.json;*.asmdef</DefaultItemExcludes>
+        <DefaultItemExcludes>$(DefaultItemExcludes);**\*.meta;package.json;*.asmdef;StrykerOutput/**</DefaultItemExcludes>
 
         <!--
             CS1573: The build doesn't understand inheritdoc, so suppress warnings for missing parameter docs

--- a/src/ResponsibleGherkin.Tests/CodeGeneratorCompilationTests.cs
+++ b/src/ResponsibleGherkin.Tests/CodeGeneratorCompilationTests.cs
@@ -34,11 +34,11 @@ public class CodeGeneratorCompilationTests
 	private static readonly string TestBaseClassCode = $@"
 using Responsible;
 
-namespace {DefaultContext.Namespace}
+namespace {DefaultConfiguration.Namespace}
 {{
-	public abstract class {DefaultContext.BaseClass}
+	public abstract class {DefaultConfiguration.BaseClass}
 	{{
-		protected TestInstructionExecutor {DefaultContext.ExecutorName} {{ get; private set; }}
+		protected TestInstructionExecutor {DefaultConfiguration.ExecutorName} {{ get; private set; }}
 	}}
 }}
 ";
@@ -52,8 +52,8 @@ namespace {DefaultContext.Namespace}
 	public void Feature_CompilesWithoutDiagnostics_WithNUnit(string featureName)
 	{
 		var document = LoadFeature(featureName);
-		var code = CodeGenerator.GenerateFile(document.Feature, FlavorType.Xunit, DefaultContext);
-		AssertCodeCompilesWithoutDiagnostics(TestBaseClassCode, code);
+		var code = CodeGenerator.GenerateClass(document.Feature, DefaultConfiguration);
+		AssertCodeCompilesWithoutDiagnostics(TestBaseClassCode, code.BuildFileContent());
 	}
 
 	private static void AssertCodeCompilesWithoutDiagnostics(params string[] codes)

--- a/src/ResponsibleGherkin.Tests/CodeGeneratorCompilationTests.cs
+++ b/src/ResponsibleGherkin.Tests/CodeGeneratorCompilationTests.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using System.Reflection;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using NUnit.Framework;
+using Xunit;
 using static ResponsibleGherkin.Tests.TestFeatures;
 
 namespace ResponsibleGherkin.Tests;
@@ -12,7 +12,7 @@ public class CodeGeneratorCompilationTests
 {
 	private static readonly Type[] MetaDataSourceTypes =
 	{
-		typeof(TestAttribute),
+		typeof(FactAttribute),
 		typeof(Responsible.Responsibly),
 	};
 
@@ -43,15 +43,16 @@ namespace {DefaultContext.Namespace}
 }}
 ";
 
-	[Test]
+	[Fact]
 	public void Precondition_TestBaseClass_CompilesWithoutDiagnostics() =>
 		AssertCodeCompilesWithoutDiagnostics(TestBaseClassCode);
 
-	[TestCase("BasicFeature")]
+	[Theory]
+	[InlineData("BasicFeature")]
 	public void Feature_CompilesWithoutDiagnostics_WithNUnit(string featureName)
 	{
 		var document = LoadFeature(featureName);
-		var code = CodeGenerator.GenerateFile(document.Feature, FlavorType.NUnit, DefaultContext);
+		var code = CodeGenerator.GenerateFile(document.Feature, FlavorType.Xunit, DefaultContext);
 		AssertCodeCompilesWithoutDiagnostics(TestBaseClassCode, code);
 	}
 
@@ -63,6 +64,6 @@ namespace {DefaultContext.Namespace}
 		var compilation = CSharpCompilation.Create("MyTests", syntaxTrees, References, options);
 		var diagnostics = compilation.GetDiagnostics();
 
-		Assert.IsEmpty(diagnostics);
+		Assert.Empty(diagnostics);
 	}
 }

--- a/src/ResponsibleGherkin.Tests/CodeGeneratorSnapshotTests.cs
+++ b/src/ResponsibleGherkin.Tests/CodeGeneratorSnapshotTests.cs
@@ -18,10 +18,10 @@ public class CodeGeneratorSnapshotTests
 
 	private static string GenerateCode(
 		string name,
-		FlavorType flavor = FlavorType.NUnit,
-		GenerationContext? context = null) =>
-		CodeGenerator.GenerateFile(
-			LoadFeature(name).Feature,
-			flavor,
-			context ?? DefaultContext);
+		FlavorType flavor = FlavorType.NUnit) =>
+		CodeGenerator
+			.GenerateClass(
+				LoadFeature(name).Feature,
+				DefaultConfiguration with { Flavor = flavor })
+			.BuildFileContent();
 }

--- a/src/ResponsibleGherkin.Tests/CodeGeneratorSnapshotTests.cs
+++ b/src/ResponsibleGherkin.Tests/CodeGeneratorSnapshotTests.cs
@@ -1,16 +1,18 @@
 using System.Threading.Tasks;
-using NUnit.Framework;
-using static VerifyNUnit.Verifier;
+using VerifyXunit;
+using Xunit;
+using static VerifyXunit.Verifier;
 using static ResponsibleGherkin.Tests.TestFeatures;
 
 namespace ResponsibleGherkin.Tests;
 
+[UsesVerify]
 public class CodeGeneratorSnapshotTests
 {
-	[Test]
+	[Fact]
 	public Task VerifyBasicFeatureFile() => Verify(GenerateCode("BasicFeature"));
 
-	[Test]
+	[Fact]
 	public Task VerifyBasicFeatureFile_WithUnity() => Verify(GenerateCode(
 		"BasicFeature", FlavorType.Unity));
 

--- a/src/ResponsibleGherkin.Tests/CodeGeneratorTests.cs
+++ b/src/ResponsibleGherkin.Tests/CodeGeneratorTests.cs
@@ -9,7 +9,7 @@ public class CodeGeneratorTests
 	{
 		var document = TestFeatures.LoadFeature("UnsupportedKeyword");
 		var exception = Assert.Throws<UnsupportedKeywordException>(() => CodeGenerator
-			.GenerateFile(document.Feature, FlavorType.NUnit, TestFeatures.DefaultContext));
+			.GenerateClass(document.Feature, TestFeatures.DefaultConfiguration));
 
 		// I'm tightly coupling the test data to this assertion, yes.
 		// Without some kind of test asset tagging, I'm not sure what would be cleaner.

--- a/src/ResponsibleGherkin.Tests/CodeGeneratorTests.cs
+++ b/src/ResponsibleGherkin.Tests/CodeGeneratorTests.cs
@@ -1,10 +1,10 @@
-using NUnit.Framework;
+using Xunit;
 
 namespace ResponsibleGherkin.Tests;
 
 public class CodeGeneratorTests
 {
-	[Test]
+	[Fact]
 	public void CodeGeneration_Fails_WithUnsupportedKeywords()
 	{
 		var document = TestFeatures.LoadFeature("UnsupportedKeyword");
@@ -13,6 +13,6 @@ public class CodeGeneratorTests
 
 		// I'm tightly coupling the test data to this assertion, yes.
 		// Without some kind of test asset tagging, I'm not sure what would be cleaner.
-		StringAssert.Contains("Unsupported step keyword: '*'", exception!.Message);
+		Assert.Contains("Unsupported step keyword: '*'", exception!.Message);
 	}
 }

--- a/src/ResponsibleGherkin.Tests/CodeGeneratorTests.cs
+++ b/src/ResponsibleGherkin.Tests/CodeGeneratorTests.cs
@@ -13,6 +13,6 @@ public class CodeGeneratorTests
 
 		// I'm tightly coupling the test data to this assertion, yes.
 		// Without some kind of test asset tagging, I'm not sure what would be cleaner.
-		Assert.Contains("Unsupported step keyword: '*'", exception!.Message);
+		Assert.Contains("Unsupported step keyword: '*'", exception.Message);
 	}
 }

--- a/src/ResponsibleGherkin.Tests/EnumValues.cs
+++ b/src/ResponsibleGherkin.Tests/EnumValues.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ResponsibleGherkin.Tests;
+
+public class EnumValues<T> : IEnumerable<object[]>
+	where T : struct, Enum
+{
+	private static readonly List<object[]> Values = Enum
+		.GetValues(typeof(T))
+		.Cast<object>()
+		.Select(val => new[] { val })
+		.ToList();
+
+	public IEnumerator<object[]> GetEnumerator() => Values.GetEnumerator();
+	IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+}

--- a/src/ResponsibleGherkin.Tests/FlavorTests.cs
+++ b/src/ResponsibleGherkin.Tests/FlavorTests.cs
@@ -1,24 +1,24 @@
 using System;
-using NUnit.Framework;
+using Xunit;
 
 namespace ResponsibleGherkin.Tests;
 
 public class FlavorTests
 {
-	[Test]
+	[Fact]
 	public void FromType_ThrowsMeaningfulException_ForInvalidType()
 	{
 		var exception = Assert.Throws<ArgumentOutOfRangeException>(
 			() => Flavor.FromType((FlavorType)42));
 
-		StringAssert.Contains("flavor", exception!.Message);
-		StringAssert.Contains("42", exception.Message);
+		Assert.Contains("flavor", exception.Message);
+		Assert.Contains("42", exception.Message);
 	}
 
-	[Test]
-	public void FromType_DoesNotThrow_ForValidType(
-		[Values] FlavorType type)
+	[Theory]
+	[ClassData(typeof(EnumValues<FlavorType>))]
+	public void FromType_DoesNotThrow_ForValidType(FlavorType type)
 	{
-		Assert.DoesNotThrow(() => Flavor.FromType(type));
+		Assert.NotNull(Flavor.FromType(type));
 	}
 }

--- a/src/ResponsibleGherkin.Tests/LineTests.cs
+++ b/src/ResponsibleGherkin.Tests/LineTests.cs
@@ -1,34 +1,40 @@
 using System.Text;
-using NUnit.Framework;
+using Xunit;
 
 namespace ResponsibleGherkin.Tests;
 
 public class LineTests
 {
-	[TestCase(1, ExpectedResult = 2)]
-	[TestCase(2, ExpectedResult = 3)]
-	public int IndentBy_IncreasesIndent_WhenOriginalIndentIsOne(int amount) =>
-		new Line("some content", 1).IndentBy(amount).Indent;
+	[Theory]
+	[InlineData(1, 2)]
+	[InlineData(2, 3)]
+	public void IndentBy_IncreasesIndent_WhenOriginalIndentIsOne(int amount, int expected) =>
+		Assert.Equal(
+			expected,
+			new Line("some content", 1).IndentBy(amount).Indent);
 
-	[TestCase("",  ExpectedResult = "")]
-	[TestCase(" \t ",  ExpectedResult = "")]
-	[TestCase("foo\t",  ExpectedResult = "\tfoo")]
-	[TestCase("\tfoo",  ExpectedResult = "\t\tfoo")]
-	public string AppendToBuilder_IndentsCorrectly_WithTabs(string lineContent)
+	[Theory]
+	[InlineData("",  "")]
+	[InlineData(" \t ", "")]
+	[InlineData("foo\t", "\tfoo")]
+	[InlineData("\tfoo", "\t\tfoo")]
+	public void AppendToBuilder_IndentsCorrectly_WithTabs(string lineContent, string expected)
 	{
 		var builder = new StringBuilder();
 		new Line(lineContent, 1).AppendToBuilder(builder, IndentInfo.Tabs);
-		return builder.ToString().TrimEnd('\n', '\r');
+
+		Assert.Equal(expected, builder.ToString().TrimEnd('\n', '\r'));
 	}
 
-	[TestCase("",  ExpectedResult = "")]
-	[TestCase(" \t ",  ExpectedResult = "")]
-	[TestCase("foo\t",  ExpectedResult = "    foo")]
-	[TestCase("\tfoo",  ExpectedResult = "    \tfoo")] // we don't touch existing tabs
-	public string AppendToBuilder_IndentsCorrectly_WithSpaces(string lineContent)
+	[Theory]
+	[InlineData("", "")]
+	[InlineData(" \t ", "")]
+	[InlineData("foo\t", "    foo")]
+	[InlineData("\tfoo", "    \tfoo")] // we don't touch existing tabs
+	public void AppendToBuilder_IndentsCorrectly_WithSpaces(string lineContent, string expected)
 	{
 		var builder = new StringBuilder();
 		new Line(lineContent, 1).AppendToBuilder(builder, IndentInfo.Spaces);
-		return builder.ToString().TrimEnd('\n', '\r');
+		Assert.Equal(expected, builder.ToString().TrimEnd('\n', '\r'));
 	}
 }

--- a/src/ResponsibleGherkin.Tests/LineTests.cs
+++ b/src/ResponsibleGherkin.Tests/LineTests.cs
@@ -1,4 +1,3 @@
-using System.Text;
 using Xunit;
 
 namespace ResponsibleGherkin.Tests;
@@ -18,12 +17,9 @@ public class LineTests
 	[InlineData(" \t ", "")]
 	[InlineData("foo\t", "\tfoo")]
 	[InlineData("\tfoo", "\t\tfoo")]
-	public void AppendToBuilder_IndentsCorrectly_WithTabs(string lineContent, string expected)
+	public void BuildString_IndentsCorrectly_WithTabs(string lineContent, string expected)
 	{
-		var builder = new StringBuilder();
-		new Line(lineContent, 1).AppendToBuilder(builder, IndentInfo.Tabs);
-
-		Assert.Equal(expected, builder.ToString().TrimEnd('\n', '\r'));
+		Assert.Equal(expected, new Line(lineContent, 1).BuildString(IndentInfo.Tabs));
 	}
 
 	[Theory]
@@ -31,10 +27,8 @@ public class LineTests
 	[InlineData(" \t ", "")]
 	[InlineData("foo\t", "    foo")]
 	[InlineData("\tfoo", "    \tfoo")] // we don't touch existing tabs
-	public void AppendToBuilder_IndentsCorrectly_WithSpaces(string lineContent, string expected)
+	public void BuildString_IndentsCorrectly_WithSpaces(string lineContent, string expected)
 	{
-		var builder = new StringBuilder();
-		new Line(lineContent, 1).AppendToBuilder(builder, IndentInfo.Spaces);
-		Assert.Equal(expected, builder.ToString().TrimEnd('\n', '\r'));
+		Assert.Equal(expected, new Line(lineContent, 1).BuildString(IndentInfo.Spaces));
 	}
 }

--- a/src/ResponsibleGherkin.Tests/PascalCaseConverterTests.cs
+++ b/src/ResponsibleGherkin.Tests/PascalCaseConverterTests.cs
@@ -1,17 +1,18 @@
-using NUnit.Framework;
+using Xunit;
 
 namespace ResponsibleGherkin.Tests;
 
 public class PascalCaseConverterTests
 {
-	[TestCase("", ExpectedResult = "")]
-	[TestCase(" ", ExpectedResult = "")]
-	[TestCase(" foo ", ExpectedResult = "Foo")]
-	[TestCase(" lots\nof\tfood ", ExpectedResult = "LotsOfFood")]
-	[TestCase(" lots     of      food ", ExpectedResult = "LotsOfFood")]
-	[TestCase("DSP scheduler", ExpectedResult = "DspScheduler")]
-	[TestCase("DspScheduler can do", ExpectedResult = "DspSchedulerCanDo")]
-	[TestCase("UI handler", ExpectedResult = "UIHandler", Ignore = "two-letter acronyms not handled")]
-	public string ConvertToPascalCase_ReturnsExceptedValue(string input)
-		=> PascalCaseConverter.ConvertToPascalCase(input);
+	[Theory]
+	[InlineData("", "")]
+	[InlineData(" ", "")]
+	[InlineData(" foo ", "Foo")]
+	[InlineData(" lots\nof\tfood ", "LotsOfFood")]
+	[InlineData(" lots     of      food ", "LotsOfFood")]
+	[InlineData("DSP scheduler", "DspScheduler")]
+	[InlineData("DspScheduler can do", "DspSchedulerCanDo")]
+	public void ConvertToPascalCase_ReturnsExceptedValue(string input, string expected) => Assert.Equal(
+		expected,
+		PascalCaseConverter.ConvertToPascalCase(input));
 }

--- a/src/ResponsibleGherkin.Tests/ProgramTests.Verify_CommandHelp_command=configure.verified.txt
+++ b/src/ResponsibleGherkin.Tests/ProgramTests.Verify_CommandHelp_command=configure.verified.txt
@@ -1,0 +1,15 @@
+﻿{
+  Out:
+Description:
+  Generate configuration file
+
+Usage:
+  responsible-gherkin configure [options]
+
+Options:
+  -?, -h, --help  Show help and usage information
+
+
+,
+  Error: 
+}

--- a/src/ResponsibleGherkin.Tests/ProgramTests.Verify_CommandHelp_command=configure.verified.txt
+++ b/src/ResponsibleGherkin.Tests/ProgramTests.Verify_CommandHelp_command=configure.verified.txt
@@ -11,7 +11,7 @@ Arguments:
   <namespace>          Namespace to put classes in
   <base-class>         Base class to derive from
   <executor>           Name of parameter that has the TestInstructionExecutor
-  <Space|Tab>          Type of indentation to use
+  <Spaces|Tabs>        Type of indentation to use
   <indent-amount>      Amount of indentation to use
 
 Options:

--- a/src/ResponsibleGherkin.Tests/ProgramTests.Verify_CommandHelp_command=configure.verified.txt
+++ b/src/ResponsibleGherkin.Tests/ProgramTests.Verify_CommandHelp_command=configure.verified.txt
@@ -1,13 +1,22 @@
 ﻿{
   Out:
 Description:
-  Generate configuration file
+  Generate a configuration to be used with generate
 
 Usage:
-  responsible-gherkin configure [options]
+  responsible-gherkin configure <flavor> <namespace> <base-class> <executor> <indent-type> <indent-amount> [options]
+
+Arguments:
+  <NUnit|Unity|Xunit>  Flavor of code generation
+  <namespace>          Namespace to put classes in
+  <base-class>         Base class to derive from
+  <executor>           Name of parameter that has the TestInstructionExecutor
+  <Space|Tab>          Type of indentation to use
+  <indent-amount>      Amount of indentation to use
 
 Options:
   -?, -h, --help  Show help and usage information
+
 
 
 ,

--- a/src/ResponsibleGherkin.Tests/ProgramTests.Verify_CommandHelp_command=generate.verified.txt
+++ b/src/ResponsibleGherkin.Tests/ProgramTests.Verify_CommandHelp_command=generate.verified.txt
@@ -7,9 +7,9 @@ Usage:
   responsible-gherkin generate <config> <input> <output> [options]
 
 Arguments:
-  <config>  Path to configuration file to use.
-  <input>   Input feature file to generate code from.
-  <output>  Directory to write content into.
+  <config>  Path to configuration file to use
+  <input>   Input feature file to generate code from
+  <output>  Directory to write content into
 
 Options:
   -?, -h, --help  Show help and usage information

--- a/src/ResponsibleGherkin.Tests/ProgramTests.Verify_CommandHelp_command=generate.verified.txt
+++ b/src/ResponsibleGherkin.Tests/ProgramTests.Verify_CommandHelp_command=generate.verified.txt
@@ -1,0 +1,21 @@
+﻿{
+  Out:
+Description:
+  Generate test case stubs
+
+Usage:
+  responsible-gherkin generate <config> <input> <output> [options]
+
+Arguments:
+  <config>  Path to configuration file to use.
+  <input>   Input feature file to generate code from.
+  <output>  Directory to write content into.
+
+Options:
+  -?, -h, --help  Show help and usage information
+
+
+
+,
+  Error: 
+}

--- a/src/ResponsibleGherkin.Tests/ProgramTests.Verify_OutputWithNoArguments.verified.txt
+++ b/src/ResponsibleGherkin.Tests/ProgramTests.Verify_OutputWithNoArguments.verified.txt
@@ -1,0 +1,12 @@
+﻿Description:
+  Generate Responsible test case stubs from Gherkin specifications.
+
+Usage:
+  responsible-gherkin <input-file> [options]
+
+Arguments:
+  <input-file>  Input feature file to generate code from.
+
+Options:
+  --version       Show version information
+  -?, -h, --help  Show help and usage information

--- a/src/ResponsibleGherkin.Tests/ProgramTests.Verify_OutputWithNoArguments.verified.txt
+++ b/src/ResponsibleGherkin.Tests/ProgramTests.Verify_OutputWithNoArguments.verified.txt
@@ -10,3 +10,6 @@ Arguments:
 Options:
   --version       Show version information
   -?, -h, --help  Show help and usage information
+
+
+

--- a/src/ResponsibleGherkin.Tests/ProgramTests.Verify_Output_WhenInputFileDoesNotExist.verified.txt
+++ b/src/ResponsibleGherkin.Tests/ProgramTests.Verify_Output_WhenInputFileDoesNotExist.verified.txt
@@ -1,0 +1,6 @@
+﻿{
+  Out: ,
+  Error:
+Could not read input: Could not find file 'fake-file'.
+
+}

--- a/src/ResponsibleGherkin.Tests/ProgramTests.Verify_Output_WhenInputFileDoesNotExist.verified.txt
+++ b/src/ResponsibleGherkin.Tests/ProgramTests.Verify_Output_WhenInputFileDoesNotExist.verified.txt
@@ -1,6 +1,0 @@
-﻿{
-  Out: ,
-  Error:
-Could not read input: Could not find file 'fake-file'.
-
-}

--- a/src/ResponsibleGherkin.Tests/ProgramTests.Verify_Output_WhenNoArguments.verified.txt
+++ b/src/ResponsibleGherkin.Tests/ProgramTests.Verify_Output_WhenNoArguments.verified.txt
@@ -4,20 +4,19 @@ Description:
   Generate Responsible test case stubs from Gherkin specifications.
 
 Usage:
-  responsible-gherkin <input-file> [options]
-
-Arguments:
-  <input-file>  Input feature file to generate code from.
+  responsible-gherkin [command] [options]
 
 Options:
   --version       Show version information
   -?, -h, --help  Show help and usage information
 
-
+Commands:
+  configure                           Generate configuration file
+  generate <config> <input> <output>  Generate test case stubs
 
 ,
   Error:
-Required argument missing for command: 'responsible-gherkin'.
+Required command was not provided.
 
 
 }

--- a/src/ResponsibleGherkin.Tests/ProgramTests.Verify_Output_WhenNoArguments.verified.txt
+++ b/src/ResponsibleGherkin.Tests/ProgramTests.Verify_Output_WhenNoArguments.verified.txt
@@ -1,4 +1,6 @@
-﻿Description:
+﻿{
+  Out:
+Description:
   Generate Responsible test case stubs from Gherkin specifications.
 
 Usage:
@@ -13,3 +15,9 @@ Options:
 
 
 
+,
+  Error:
+Required argument missing for command: 'responsible-gherkin'.
+
+
+}

--- a/src/ResponsibleGherkin.Tests/ProgramTests.Verify_Output_WhenNoArguments.verified.txt
+++ b/src/ResponsibleGherkin.Tests/ProgramTests.Verify_Output_WhenNoArguments.verified.txt
@@ -18,8 +18,8 @@ Options:
   -?, -h, --help  Show help and usage information
 
 Commands:
-  configure <NUnit|Unity|Xunit> <namespace> <base-class> <executor> <Space|Tab> <indent-amount>  Generate a configuration to be used with generate
-  generate <config> <input> <output>                                                             Generate test case stubs
+  configure <NUnit|Unity|Xunit> <namespace> <base-class> <executor> <Spaces|Tabs> <indent-amount>  Generate a configuration to be used with generate
+  generate <config> <input> <output>                                                               Generate test case stubs
 
 ,
   Error:

--- a/src/ResponsibleGherkin.Tests/ProgramTests.Verify_Output_WhenNoArguments.verified.txt
+++ b/src/ResponsibleGherkin.Tests/ProgramTests.Verify_Output_WhenNoArguments.verified.txt
@@ -2,6 +2,13 @@
   Out:
 Description:
   Generate Responsible test case stubs from Gherkin specifications.
+  
+  First generate a configuration using
+      responsible-gherkin configure ...
+  
+  store it to a file, and then generate your code using
+      responsible-gherkin generate ...
+  
 
 Usage:
   responsible-gherkin [command] [options]
@@ -11,8 +18,8 @@ Options:
   -?, -h, --help  Show help and usage information
 
 Commands:
-  configure                           Generate configuration file
-  generate <config> <input> <output>  Generate test case stubs
+  configure <NUnit|Unity|Xunit> <namespace> <base-class> <executor> <Space|Tab> <indent-amount>  Generate a configuration to be used with generate
+  generate <config> <input> <output>                                                             Generate test case stubs
 
 ,
   Error:

--- a/src/ResponsibleGherkin.Tests/ProgramTests.Verify_SuccessfulConfigure.verified.txt
+++ b/src/ResponsibleGherkin.Tests/ProgramTests.Verify_SuccessfulConfigure.verified.txt
@@ -1,0 +1,15 @@
+﻿{
+  Out:
+{
+  "Flavor": "Xunit",
+  "IndentInfo": {
+    "Amount": 1,
+    "Type": "Tabs"
+  },
+  "Namespace": "MyNamespace",
+  "BaseClass": "BddTest",
+  "ExecutorName": "Executor"
+}
+,
+  Error: 
+}

--- a/src/ResponsibleGherkin.Tests/ProgramTests.cs
+++ b/src/ResponsibleGherkin.Tests/ProgramTests.cs
@@ -1,0 +1,34 @@
+using System.CommandLine;
+using System.CommandLine.IO;
+using System.IO.Abstractions.TestingHelpers;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using static VerifyNUnit.Verifier;
+
+namespace ResponsibleGherkin.Tests;
+
+public class ProgramTests
+{
+	private MockFileSystem fileSystem;
+	private TestConsole console;
+
+	[SetUp]
+	public void SetUp()
+	{
+		this.fileSystem = new MockFileSystem();
+		this.console = new TestConsole();
+	}
+
+	[Test]
+	public Task Verify_OutputWithNoArguments()
+	{
+		this.Run();
+		return Verify(this.Output());
+	}
+
+	private void Run(params string[] args) => Program
+		.BuildRootCommand(this.fileSystem)
+		.Invoke(args, this.console);
+
+	private string Output() => this.console.Out.ToString()!;
+}

--- a/src/ResponsibleGherkin.Tests/ProgramTests.cs
+++ b/src/ResponsibleGherkin.Tests/ProgramTests.cs
@@ -2,24 +2,19 @@ using System.CommandLine;
 using System.CommandLine.IO;
 using System.IO.Abstractions.TestingHelpers;
 using System.Threading.Tasks;
-using NUnit.Framework;
-using static VerifyNUnit.Verifier;
+using VerifyXunit;
+using Xunit;
+using static VerifyXunit.Verifier;
 
 namespace ResponsibleGherkin.Tests;
 
+[UsesVerify]
 public class ProgramTests
 {
-	private MockFileSystem fileSystem;
-	private TestConsole console;
+	private readonly MockFileSystem fileSystem = new();
+	private readonly TestConsole console = new();
 
-	[SetUp]
-	public void SetUp()
-	{
-		this.fileSystem = new MockFileSystem();
-		this.console = new TestConsole();
-	}
-
-	[Test]
+	[Fact]
 	public Task Verify_OutputWithNoArguments()
 	{
 		this.Run();

--- a/src/ResponsibleGherkin.Tests/ProgramTests.cs
+++ b/src/ResponsibleGherkin.Tests/ProgramTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.CommandLine;
 using System.CommandLine.IO;
 using System.IO.Abstractions.TestingHelpers;
@@ -14,11 +15,26 @@ public class ProgramTests
 	private readonly MockFileSystem fileSystem = new();
 	private readonly TestConsole console = new();
 
-	[Fact]
-	public Task Verify_Output_WhenNoArguments()
+	public ProgramTests()
 	{
-		this.Run();
-		return Verify(this.ConsoleOutput());
+		this.fileSystem.AddFile(
+			"config.json",
+			new MockFileData(TestFeatures.DefaultConfigurationJson));
+
+		this.fileSystem.AddFile(
+			"MinimalFeature.feature",
+			TestFeatures.MinimalFeatureString);
+
+		this.fileSystem.AddFile(
+			"InvalidFeature.feature",
+			new MockFileData("foobar"));
+	}
+
+	[Fact]
+	public async Task Verify_Output_WhenNoArguments()
+	{
+		this.RunAssertingFailure();
+		await Verify(this.ConsoleOutput());
 	}
 
 	[Theory]
@@ -26,11 +42,72 @@ public class ProgramTests
 	[InlineData("generate")]
 	public async Task Verify_CommandHelp(string command)
 	{
-		this.Run(command, "-h");
+		this.RunAssertingSuccess(command, "-h");
 		await Verify(this.ConsoleOutput()).UseParameters(command);
 	}
 
-	private void Run(params string[] args) => Program
+	[Fact]
+	public async Task Verify_SuccessfulConfigure()
+	{
+		this.RunAssertingSuccess("configure", "xunit", "MyNamespace", "BddTest", "Executor", "tabs", "1");
+		await Verify(this.ConsoleOutput());
+	}
+
+	[Fact]
+	public void Generate_ProducesSameResultAsManualInvoke()
+	{
+		var expected = CodeGenerator.GenerateClass(
+				TestFeatures.LoadFeature("MinimalFeature").Feature,
+				TestFeatures.DefaultConfiguration)
+			.BuildFileContent();
+
+		this.RunAssertingSuccess("generate", "config.json", "MinimalFeature.feature", "./");
+		var generatedContent = this.fileSystem.File.ReadAllText("MinimalFeature.cs");
+
+		Assert.Equal(expected, generatedContent);
+	}
+
+	[Fact]
+	public void Generate_ContainsDescriptiveError_WhenConfigFileIsMissing()
+	{
+		this.RunAssertingFailure("generate", "foobar", "MinimalFeature.feature", "./");
+		Assert.Contains("read configuration", this.console.Error.ToString()!);
+	}
+
+	[Fact]
+	public void Generate_ContainsDescriptiveError_WhenInputFileIsMissing()
+	{
+		this.RunAssertingFailure("generate", "config.json", "foobar", "./");
+		Assert.Contains("read input", this.console.Error.ToString()!);
+	}
+
+	[Fact]
+	public void Generate_ContainsDescriptiveError_WhenInputFileIsInvalid()
+	{
+		this.RunAssertingFailure("generate", "config.json", "InvalidFeature.feature", "./");
+		Assert.Contains("read input", this.console.Error.ToString()!);
+	}
+
+	[Fact]
+	public void Generate_ContainsDescriptiveError_WhenDirectoryIsInvalid()
+	{
+		this.RunAssertingFailure("generate", "config.json", "MinimalFeature.feature", "......");
+		Assert.Contains("write output", this.console.Error.ToString()!);
+	}
+
+	private void RunAssertingFailure(params string[] args)
+	{
+		var result = this.Run(args);
+		Assert.True(result != 0, $"Run should fail, output was {this.console.Out}");
+	}
+
+	private void RunAssertingSuccess(params string[] args)
+	{
+		var result = this.Run(args);
+		Assert.True(result == 0, $"Run should succeed, failed with {this.console.Error}");
+	}
+
+	private int Run(params string[] args) => Program
 		.BuildRootCommand(this.fileSystem)
 		.Invoke(args, this.console);
 

--- a/src/ResponsibleGherkin.Tests/ProgramTests.cs
+++ b/src/ResponsibleGherkin.Tests/ProgramTests.cs
@@ -21,11 +21,13 @@ public class ProgramTests
 		return Verify(this.ConsoleOutput());
 	}
 
-	[Fact]
-	public Task Verify_Output_WhenInputFileDoesNotExist()
+	[Theory]
+	[InlineData("configure")]
+	[InlineData("generate")]
+	public async Task Verify_CommandHelp(string command)
 	{
-		this.Run("fake-file");
-		return Verify(this.ConsoleOutput());
+		this.Run(command, "-h");
+		await Verify(this.ConsoleOutput()).UseParameters(command);
 	}
 
 	private void Run(params string[] args) => Program

--- a/src/ResponsibleGherkin.Tests/ProgramTests.cs
+++ b/src/ResponsibleGherkin.Tests/ProgramTests.cs
@@ -15,15 +15,26 @@ public class ProgramTests
 	private readonly TestConsole console = new();
 
 	[Fact]
-	public Task Verify_OutputWithNoArguments()
+	public Task Verify_Output_WhenNoArguments()
 	{
 		this.Run();
-		return Verify(this.Output());
+		return Verify(this.ConsoleOutput());
+	}
+
+	[Fact]
+	public Task Verify_Output_WhenInputFileDoesNotExist()
+	{
+		this.Run("fake-file");
+		return Verify(this.ConsoleOutput());
 	}
 
 	private void Run(params string[] args) => Program
 		.BuildRootCommand(this.fileSystem)
 		.Invoke(args, this.console);
 
-	private string Output() => this.console.Out.ToString()!;
+	private object ConsoleOutput() => new
+	{
+		Out = this.console.Out.ToString(),
+		Error = this.console.Error.ToString(),
+	};
 }

--- a/src/ResponsibleGherkin.Tests/ProgramTests.cs
+++ b/src/ResponsibleGherkin.Tests/ProgramTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.CommandLine;
 using System.CommandLine.IO;
 using System.IO.Abstractions.TestingHelpers;
@@ -24,6 +23,10 @@ public class ProgramTests
 		this.fileSystem.AddFile(
 			"MinimalFeature.feature",
 			TestFeatures.MinimalFeatureString);
+
+		this.fileSystem.AddFile(
+			"UnsupportedKeyword.feature",
+			TestFeatures.UnsupportedKeywordFeatureString);
 
 		this.fileSystem.AddFile(
 			"InvalidFeature.feature",
@@ -89,10 +92,25 @@ public class ProgramTests
 	}
 
 	[Fact]
+	public void Generate_ContainsDescriptiveError_WhenInputFileIsNotSupported()
+	{
+		this.RunAssertingFailure("generate", "config.json", "UnsupportedKeyword.feature", "./");
+		Assert.Contains("generate code", this.console.Error.ToString()!);
+	}
+
+	[Fact]
 	public void Generate_ContainsDescriptiveError_WhenDirectoryIsInvalid()
 	{
-		this.RunAssertingFailure("generate", "config.json", "MinimalFeature.feature", "......");
+		this.RunAssertingFailure("generate", "config.json", "MinimalFeature.feature", "*");
 		Assert.Contains("write output", this.console.Error.ToString()!);
+	}
+
+	[Fact]
+	public void Generate_CreatesOutputDirectory_WhenItDoesNotExist()
+	{
+		this.RunAssertingSuccess("generate", "config.json", "MinimalFeature.feature", "./Output");
+		Assert.True(this.fileSystem.Directory.Exists("Output"));
+		Assert.True(this.fileSystem.File.Exists("Output/MinimalFeature.cs"));
 	}
 
 	private void RunAssertingFailure(params string[] args)

--- a/src/ResponsibleGherkin.Tests/ResponsibleGherkin.Tests.csproj
+++ b/src/ResponsibleGherkin.Tests/ResponsibleGherkin.Tests.csproj
@@ -15,6 +15,10 @@
         <PackageReference Include="Verify.Xunit" Version="16.5.4" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.analyzers" Version="0.10.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/ResponsibleGherkin.Tests/ResponsibleGherkin.Tests.csproj
+++ b/src/ResponsibleGherkin.Tests/ResponsibleGherkin.Tests.csproj
@@ -10,11 +10,11 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-        <PackageReference Include="NUnit" Version="3.13.3" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
         <PackageReference Include="coverlet.collector" Version="3.1.0" />
         <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="16.1.25" />
-        <PackageReference Include="Verify.NUnit" Version="16.5.4" />
+        <PackageReference Include="Verify.Xunit" Version="16.5.4" />
+        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit.analyzers" Version="0.10.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/ResponsibleGherkin.Tests/ResponsibleGherkin.Tests.csproj
+++ b/src/ResponsibleGherkin.Tests/ResponsibleGherkin.Tests.csproj
@@ -13,6 +13,7 @@
         <PackageReference Include="NUnit" Version="3.13.3" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
         <PackageReference Include="coverlet.collector" Version="3.1.0" />
+        <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="16.1.25" />
         <PackageReference Include="Verify.NUnit" Version="16.5.4" />
     </ItemGroup>
 

--- a/src/ResponsibleGherkin.Tests/ResponsibleGherkin.Tests.csproj
+++ b/src/ResponsibleGherkin.Tests/ResponsibleGherkin.Tests.csproj
@@ -29,6 +29,9 @@
       <None Update="TestFeatures\UnsupportedKeyword.feature">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>
+      <None Update="TestFeatures\MinimalFeature.feature">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
     </ItemGroup>
 
 </Project>

--- a/src/ResponsibleGherkin.Tests/SupportedKeywordsTests.cs
+++ b/src/ResponsibleGherkin.Tests/SupportedKeywordsTests.cs
@@ -1,11 +1,12 @@
-using NUnit.Framework;
+using Xunit;
 
 namespace ResponsibleGherkin.Tests;
 
 public class SupportedKeywordsTests
 {
-	[TestCase("When", ExpectedResult = true)]
-	[TestCase("Ultimately", ExpectedResult = false)]
-	public bool IsSupportedKeyword_ReturnsExpectedValue(string str) =>
-		str.IsSupportedKeyword();
+	[Theory]
+	[InlineData("When", true)]
+	[InlineData("Ultimately", false)]
+	public void IsSupportedKeyword_ReturnsExpectedValue(string str, bool expected) =>
+		Assert.Equal(expected, str.IsSupportedKeyword());
 }

--- a/src/ResponsibleGherkin.Tests/TestFeatures.cs
+++ b/src/ResponsibleGherkin.Tests/TestFeatures.cs
@@ -22,8 +22,7 @@ internal static class TestFeatures
 	    File.ReadAllText(FeatureFileName("UnsupportedKeyword"));
 
 	public static GherkinDocument LoadFeature(string featureName) =>
-		new Parser { StopAtFirstError = true }
-			.Parse(FeatureFileName(featureName));
+		new Parser().Parse(FeatureFileName(featureName));
 
 	private static string FeatureFileName(string featureName) =>
 		$"TestFeatures/{featureName}.feature";

--- a/src/ResponsibleGherkin.Tests/TestFeatures.cs
+++ b/src/ResponsibleGherkin.Tests/TestFeatures.cs
@@ -5,10 +5,12 @@ namespace ResponsibleGherkin.Tests;
 
 internal static class TestFeatures
 {
-	public static readonly GenerationContext DefaultContext = new(
+	public static readonly Configuration DefaultConfiguration = new(
+		FlavorType.Xunit,
+		IndentInfo.Tabs,
 		"MyNamespace",
 		"MyTestBase",
-		IndentInfo.Tabs);
+		"Executor");
 
 	public static GherkinDocument LoadFeature(string featureName) =>
 		new Parser { StopAtFirstError = true }

--- a/src/ResponsibleGherkin.Tests/TestFeatures.cs
+++ b/src/ResponsibleGherkin.Tests/TestFeatures.cs
@@ -1,3 +1,5 @@
+using System.IO;
+using System.Text.Json;
 using Gherkin;
 using Gherkin.Ast;
 
@@ -11,6 +13,10 @@ internal static class TestFeatures
 		"MyNamespace",
 		"MyTestBase",
 		"Executor");
+
+	public static readonly string DefaultConfigurationJson = JsonSerializer.Serialize(DefaultConfiguration);
+
+	public static readonly string MinimalFeatureString = File.ReadAllText(FeatureFileName("MinimalFeature"));
 
 	public static GherkinDocument LoadFeature(string featureName) =>
 		new Parser { StopAtFirstError = true }

--- a/src/ResponsibleGherkin.Tests/TestFeatures.cs
+++ b/src/ResponsibleGherkin.Tests/TestFeatures.cs
@@ -16,7 +16,10 @@ internal static class TestFeatures
 
 	public static readonly string DefaultConfigurationJson = JsonSerializer.Serialize(DefaultConfiguration);
 
-	public static readonly string MinimalFeatureString = File.ReadAllText(FeatureFileName("MinimalFeature"));
+  	public static readonly string MinimalFeatureString = File.ReadAllText(FeatureFileName("MinimalFeature"));
+
+    public static readonly string UnsupportedKeywordFeatureString =
+	    File.ReadAllText(FeatureFileName("UnsupportedKeyword"));
 
 	public static GherkinDocument LoadFeature(string featureName) =>
 		new Parser { StopAtFirstError = true }

--- a/src/ResponsibleGherkin.Tests/TestFeatures/MinimalFeature.feature
+++ b/src/ResponsibleGherkin.Tests/TestFeatures/MinimalFeature.feature
@@ -1,0 +1,6 @@
+Feature: Minimal feature
+
+  Scenario: Minimal scenario
+    Given I have ice cream
+    When I eat it
+    Then I will be happy

--- a/src/ResponsibleGherkin.Tests/UsingDirectivesTests.cs
+++ b/src/ResponsibleGherkin.Tests/UsingDirectivesTests.cs
@@ -1,17 +1,17 @@
 using System.Linq;
-using NUnit.Framework;
+using Xunit;
 
 namespace ResponsibleGherkin.Tests;
 
 public class UsingDirectivesTests
 {
-	[Test]
+	[Fact]
 	public void UsingDirectives_AreSortedAlphabetically()
 	{
 		var lines = UsingDirectivesGenerator.Generate(
 			Flavor.NUnit with { RequiredNamespaces = new[] { "aac", "aaa", "aab" } });
 
-		Assert.AreEqual(
+		Assert.Equal(
 			new[]
 			{
 				"using aaa;",

--- a/src/ResponsibleGherkin/CodeGenerator.cs
+++ b/src/ResponsibleGherkin/CodeGenerator.cs
@@ -1,33 +1,31 @@
-using System.Text;
 using Gherkin.Ast;
 
 namespace ResponsibleGherkin;
 
 public static class CodeGenerator
 {
-	public static string GenerateFile(
+	public static GeneratedClass GenerateClass(
 		Feature feature,
-		FlavorType flavorType,
-		GenerationContext context)
+		Configuration configuration)
 	{
-		var builder = new StringBuilder();
-		var flavor = Flavor.FromType(flavorType);
-		var indentInfo = context.IndentInfo;
+		List<string> lines = new();
+		var indentInfo = configuration.IndentInfo;
+		var flavor = Flavor.FromType(configuration.Flavor);
 
 		UsingDirectivesGenerator.Generate(flavor)
-			.AppendToBuilder(builder, indentInfo);
+			.AppendToList(lines, indentInfo);
 
-		builder.AppendLine();
+		lines.Add("");
 
 		// TODO: support file-level namespaces?
-		builder.AppendLine($"namespace {context.Namespace}");
-		builder.AppendLine("{");
+		lines.Add($"namespace {configuration.Namespace}");
+		lines.Add("{");
 
-		FeatureGenerator.Generate(feature, flavor, context)
-			.AppendToBuilder(builder, indentInfo, indentBy: 1);
+		FeatureGenerator.Generate(feature, flavor, configuration)
+			.AppendToList(lines, indentInfo, indentBy: 1);
 
-		builder.AppendLine("}");
+		lines.Add("}");
 
-		return builder.ToString();
+		return new GeneratedClass(feature.Name.ToPascalCase(), lines);
 	}
 }

--- a/src/ResponsibleGherkin/Configuration.cs
+++ b/src/ResponsibleGherkin/Configuration.cs
@@ -1,0 +1,8 @@
+namespace ResponsibleGherkin;
+
+public record struct Configuration(
+	FlavorType Flavor,
+	IndentInfo IndentInfo,
+	string Namespace,
+	string BaseClass,
+	string ExecutorName);

--- a/src/ResponsibleGherkin/FeatureGenerator.cs
+++ b/src/ResponsibleGherkin/FeatureGenerator.cs
@@ -7,9 +7,9 @@ public static class FeatureGenerator
 	public static IEnumerable<Line> Generate(
 		Feature feature,
 		Flavor flavor,
-		GenerationContext context)
+		Configuration configuration)
 	{
-		yield return $"public class {feature.Name.ToPascalCase()} : {context.BaseClass}";
+		yield return $"public class {feature.Name.ToPascalCase()} : {configuration.BaseClass}";
 		yield return "{";
 
 		var scenarios = feature.Children.OfType<Scenario>().ToList();
@@ -19,7 +19,7 @@ public static class FeatureGenerator
 		foreach (var (scenario, isLast) in scenarios
 			.Select((s, i) => (s, i == scenarios.Count - 1)))
 		{
-			foreach (var scenarioLine in ScenarioGenerator.Generate(scenario, flavor, context))
+			foreach (var scenarioLine in ScenarioGenerator.Generate(scenario, flavor, configuration))
 			{
 				yield return scenarioLine.IndentBy(1);
 			}

--- a/src/ResponsibleGherkin/Flavor.cs
+++ b/src/ResponsibleGherkin/Flavor.cs
@@ -26,10 +26,21 @@ public record Flavor(
 		"Task",
 		"RunScenario");
 
+	public static readonly Flavor Xunit = new(
+		new[]
+		{
+			"System.Threading.Tasks",
+			"Xunit",
+		},
+		"Fact",
+		"Task",
+		"RunScenario");
+
 	public static Flavor FromType(FlavorType type) => type switch
 	{
 		FlavorType.Unity => Unity,
 		FlavorType.NUnit => NUnit,
+		FlavorType.Xunit => Xunit,
 		_ => throw new ArgumentOutOfRangeException(
 			nameof(type), type, "Invalid flavor of code generation"),
 	};

--- a/src/ResponsibleGherkin/FlavorType.cs
+++ b/src/ResponsibleGherkin/FlavorType.cs
@@ -1,5 +1,8 @@
+using System.Text.Json.Serialization;
+
 namespace ResponsibleGherkin;
 
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum FlavorType
 {
 	Unity,

--- a/src/ResponsibleGherkin/FlavorType.cs
+++ b/src/ResponsibleGherkin/FlavorType.cs
@@ -4,4 +4,5 @@ public enum FlavorType
 {
 	Unity,
 	NUnit,
+	Xunit,
 }

--- a/src/ResponsibleGherkin/GeneratedClass.cs
+++ b/src/ResponsibleGherkin/GeneratedClass.cs
@@ -8,6 +8,9 @@ public record GeneratedClass(
 {
 	public string BuildFileContent()
 	{
+		// String builder initial allocation is just optimization,
+		// No tests will fail if this is modified:
+		// Stryker disable once all
 		var stringBuilder = new StringBuilder(
 			this.FileLines.Sum(line => line.Length + Environment.NewLine.Length));
 

--- a/src/ResponsibleGherkin/GeneratedClass.cs
+++ b/src/ResponsibleGherkin/GeneratedClass.cs
@@ -1,0 +1,23 @@
+using System.Text;
+
+namespace ResponsibleGherkin;
+
+public record GeneratedClass(
+	string ClassName,
+	IReadOnlyList<string> FileLines)
+{
+	public string BuildFileContent()
+	{
+		var stringBuilder = new StringBuilder(
+			this.FileLines.Sum(line => line.Length + Environment.NewLine.Length));
+
+		foreach (var line in this.FileLines)
+		{
+			stringBuilder.AppendLine(line);
+		}
+
+		return stringBuilder.ToString();
+	}
+
+	public string ClassFileName() => $"{this.ClassName}.cs";
+}

--- a/src/ResponsibleGherkin/GenerationContext.cs
+++ b/src/ResponsibleGherkin/GenerationContext.cs
@@ -1,7 +1,0 @@
-namespace ResponsibleGherkin;
-
-public record GenerationContext(
-	string Namespace,
-	string BaseClass,
-	IndentInfo IndentInfo,
-	string ExecutorName = "Executor");

--- a/src/ResponsibleGherkin/IndentInfo.cs
+++ b/src/ResponsibleGherkin/IndentInfo.cs
@@ -4,9 +4,9 @@ namespace ResponsibleGherkin;
 
 public readonly record struct IndentInfo(int Amount, IndentType Type)
 {
-	public static readonly IndentInfo Tabs = new IndentInfo(1, IndentType.Tab);
-	public static readonly IndentInfo Spaces = new IndentInfo(4, IndentType.Space);
+	public static readonly IndentInfo Tabs = new IndentInfo(1, IndentType.Tabs);
+	public static readonly IndentInfo Spaces = new IndentInfo(4, IndentType.Spaces);
 
 	[JsonIgnore]
-	public char Character => this.Type == IndentType.Tab ? '\t' : ' ';
+	public char Character => this.Type == IndentType.Tabs ? '\t' : ' ';
 }

--- a/src/ResponsibleGherkin/IndentInfo.cs
+++ b/src/ResponsibleGherkin/IndentInfo.cs
@@ -1,7 +1,9 @@
 namespace ResponsibleGherkin;
 
-public readonly record struct IndentInfo(int Amount, char Character)
+public readonly record struct IndentInfo(int Amount, IndentType Type)
 {
-	public static readonly IndentInfo Tabs = new IndentInfo(1, '\t');
-	public static readonly IndentInfo Spaces = new IndentInfo(4, ' ');
+	public static readonly IndentInfo Tabs = new IndentInfo(1, IndentType.Tab);
+	public static readonly IndentInfo Spaces = new IndentInfo(4, IndentType.Space);
+
+	public char Character => this.Type == IndentType.Tab ? '\t' : ' ';
 }

--- a/src/ResponsibleGherkin/IndentInfo.cs
+++ b/src/ResponsibleGherkin/IndentInfo.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace ResponsibleGherkin;
 
 public readonly record struct IndentInfo(int Amount, IndentType Type)
@@ -5,5 +7,6 @@ public readonly record struct IndentInfo(int Amount, IndentType Type)
 	public static readonly IndentInfo Tabs = new IndentInfo(1, IndentType.Tab);
 	public static readonly IndentInfo Spaces = new IndentInfo(4, IndentType.Space);
 
+	[JsonIgnore]
 	public char Character => this.Type == IndentType.Tab ? '\t' : ' ';
 }

--- a/src/ResponsibleGherkin/IndentType.cs
+++ b/src/ResponsibleGherkin/IndentType.cs
@@ -1,5 +1,8 @@
+using System.Text.Json.Serialization;
+
 namespace ResponsibleGherkin;
 
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum IndentType
 {
 	Tab,

--- a/src/ResponsibleGherkin/IndentType.cs
+++ b/src/ResponsibleGherkin/IndentType.cs
@@ -1,0 +1,7 @@
+namespace ResponsibleGherkin;
+
+public enum IndentType
+{
+	Tab,
+	Space,
+}

--- a/src/ResponsibleGherkin/IndentType.cs
+++ b/src/ResponsibleGherkin/IndentType.cs
@@ -5,6 +5,6 @@ namespace ResponsibleGherkin;
 [JsonConverter(typeof(JsonStringEnumConverter))]
 public enum IndentType
 {
-	Tab,
-	Space,
+	Tabs,
+	Spaces,
 }

--- a/src/ResponsibleGherkin/Line.cs
+++ b/src/ResponsibleGherkin/Line.cs
@@ -8,15 +8,17 @@ public readonly record struct Line(string Content, int Indent = 0)
 		? this with { Indent = this.Indent + amount }
 		: this;
 
-	public void AppendToBuilder(StringBuilder stringBuilder, IndentInfo indentInfo)
+	public string BuildString(IndentInfo indentInfo)
 	{
+		StringBuilder stringBuilder = new();
 		var endTrimmed = this.Content.TrimEnd();
 		if (endTrimmed != "")
 		{
 			stringBuilder.Append(indentInfo.Character, this.Indent * indentInfo.Amount);
 		}
 
-		stringBuilder.AppendLine(endTrimmed);
+		stringBuilder.Append(endTrimmed);
+		return stringBuilder.ToString();
 	}
 
 	public static implicit operator Line(string content) => new(content);

--- a/src/ResponsibleGherkin/LineExtensions.cs
+++ b/src/ResponsibleGherkin/LineExtensions.cs
@@ -1,5 +1,3 @@
-using System.Text;
-
 namespace ResponsibleGherkin;
 
 public static class LineExtensions

--- a/src/ResponsibleGherkin/LineExtensions.cs
+++ b/src/ResponsibleGherkin/LineExtensions.cs
@@ -4,15 +4,15 @@ namespace ResponsibleGherkin;
 
 public static class LineExtensions
 {
-	public static void AppendToBuilder(
+	public static void AppendToList(
 		this IEnumerable<Line> lines,
-		StringBuilder stringBuilder,
+		IList<string> resultList,
 		IndentInfo indentInfo,
 		int indentBy = 0)
 	{
 		foreach (var line in lines)
 		{
-			line.IndentBy(indentBy).AppendToBuilder(stringBuilder, indentInfo);
+			resultList.Add(line.IndentBy(indentBy).BuildString(indentInfo));
 		}
 	}
 }

--- a/src/ResponsibleGherkin/Program.cs
+++ b/src/ResponsibleGherkin/Program.cs
@@ -163,7 +163,7 @@ store it to a file, and then generate your code using
 					var feature = Run("read input", () =>
 					{
 						using var fileReader = fileSystem.File.OpenText(inputFile);
-						var document = new Parser { StopAtFirstError = true }.Parse(fileReader);
+						var document = new Parser().Parse(fileReader);
 						return document.Feature;
 					});
 

--- a/src/ResponsibleGherkin/Program.cs
+++ b/src/ResponsibleGherkin/Program.cs
@@ -1,12 +1,32 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System.CommandLine;
+using System.CommandLine.IO;
+using System.Diagnostics.CodeAnalysis;
+using System.IO.Abstractions;
 
 namespace ResponsibleGherkin;
 
-[ExcludeFromCodeCoverage]
 public static class Program
 {
-	public static void Main()
+	// This only binds the root command invocation to the real file system and console.
+	// I.e. deals only with non-testable parts.
+	[ExcludeFromCodeCoverage]
+	public static void Main(string[] args) =>
+		BuildRootCommand(new FileSystem())
+			.Invoke(args, new SystemConsole());
+
+	public static RootCommand BuildRootCommand(IFileSystem fileSystem)
 	{
-		Console.WriteLine("I'm not ready to be invoked from the CLI Yet!");
+		var inputFileArgument = new Argument<string>(
+			"input-file",
+			"Input feature file to generate code from.");
+
+		var rootCommand = new RootCommand("Generate Responsible test case stubs from Gherkin specifications.")
+		{
+			inputFileArgument,
+		};
+
+		rootCommand.Name = "responsible-gherkin";
+
+		return rootCommand;
 	}
 }

--- a/src/ResponsibleGherkin/Program.cs
+++ b/src/ResponsibleGherkin/Program.cs
@@ -167,12 +167,13 @@ store it to a file, and then generate your code using
 						return document.Feature;
 					});
 
-					var content = Run("generate content", () => CodeGenerator.GenerateClass(
+					var content = Run("generate code", () => CodeGenerator.GenerateClass(
 						feature,
 						configuration));
 
 					var _ = Run("write output", () =>
 					{
+						fileSystem.Directory.CreateDirectory(outputDirectory);
 						fileSystem.File.WriteAllLines(
 							Path.Combine(outputDirectory, content.ClassFileName()),
 							content.FileLines);

--- a/src/ResponsibleGherkin/Program.cs
+++ b/src/ResponsibleGherkin/Program.cs
@@ -3,8 +3,8 @@ using System.CommandLine.Invocation;
 using System.CommandLine.IO;
 using System.Diagnostics.CodeAnalysis;
 using System.IO.Abstractions;
+using System.Text.Json;
 using Gherkin;
-using Gherkin.Ast;
 
 namespace ResponsibleGherkin;
 
@@ -13,44 +13,113 @@ public static class Program
 	// This only binds the root command invocation to the real file system and console.
 	// I.e. deals only with non-testable parts.
 	[ExcludeFromCodeCoverage]
-	public static void Main(string[] args) =>
+	public static int Main(string[] args) =>
 		BuildRootCommand(new FileSystem())
 			.Invoke(args, new SystemConsole());
 
 	public static RootCommand BuildRootCommand(IFileSystem fileSystem)
 	{
-		var inputFileArgument = new Argument<string>(
-			"input-file",
-			"Input feature file to generate code from.");
-
-		var rootCommand = new RootCommand("Generate Responsible test case stubs from Gherkin specifications.")
+		var rootCommand = new RootCommand(
+			"Generate Responsible test case stubs from Gherkin specifications.")
 		{
-			inputFileArgument,
+			ConfigureCommand(),
+			GenerateCommand(fileSystem),
 		};
 
 		rootCommand.Name = "responsible-gherkin";
-
-		rootCommand.SetHandler(
-			(string inputFile,
-				InvocationContext ctx) =>
-			{
-				try
-				{
-					GherkinDocument document;
-					using (var fileReader = fileSystem.File.OpenText(inputFile))
-					{
-						document = new Parser { StopAtFirstError = true }.Parse(fileReader);
-					}
-
-					CodeGenerator.GenerateFile(document.Feature, default, default);
-				}
-				catch (IOException exception)
-				{
-					ctx.Console.Error.WriteLine($"Could not read input: {exception.Message}");
-				}
-			},
-			inputFileArgument);
+		rootCommand.TreatUnmatchedTokensAsErrors = true;
 
 		return rootCommand;
+	}
+
+	private static Command ConfigureCommand()
+	{
+		var flavorOption = new Option<FlavorType>(
+			new[] { "--flavor", "-f" },
+			"Flavor of code to generate.");
+
+		var command = new Command("configure", "Generate configuration file");
+		return command;
+	}
+
+	private static Command GenerateCommand(IFileSystem fileSystem)
+	{
+		var configFileArgument = new Argument<string>(
+			"config",
+			"Path to configuration file to use.");
+
+		var inputFileArgument = new Argument<string>(
+			"input",
+			"Input feature file to generate code from.");
+
+		var outputDirectoryArgument = new Argument<string>(
+			"output",
+			"Directory to write content into.");
+
+		var generateCommand = new Command("generate", "Generate test case stubs")
+		{
+			configFileArgument,
+			inputFileArgument,
+			outputDirectoryArgument,
+		};
+
+		generateCommand.SetHandler(
+			(
+				string configFile,
+				string inputFile,
+				string outputDirectory,
+				InvocationContext invocationContext) =>
+			{
+				T Run<T>(string name, Func<T> operation)
+				{
+					try
+					{
+						return operation();
+					}
+					catch (Exception exception)
+					{
+						invocationContext.Console.Error.WriteLine($"Could not {name}: {exception.Message}");
+						throw;
+					}
+				}
+
+				try
+				{
+					var configuration = Run("read configuration", () =>
+					{
+						using var fileReader = fileSystem.File.OpenRead(configFile);
+						return JsonSerializer.Deserialize<Configuration>(fileReader);
+					});
+
+					var feature = Run("read input", () =>
+					{
+						using var fileReader = fileSystem.File.OpenText(inputFile);
+						var document = new Parser { StopAtFirstError = true }.Parse(fileReader);
+						return document.Feature;
+					});
+
+					var content = Run("generate content", () => CodeGenerator.GenerateClass(
+						feature,
+						configuration));
+
+					var _ = Run("write output", () =>
+					{
+						fileSystem.File.WriteAllLines(
+							Path.Combine(outputDirectory, content.ClassFileName()),
+							content.FileLines);
+						return 0;
+					});
+
+				}
+				catch
+				{
+					invocationContext.ExitCode = 1;
+				}
+			},
+			configFileArgument,
+			inputFileArgument,
+			outputDirectoryArgument);
+
+		return generateCommand;
 	}
 }

--- a/src/ResponsibleGherkin/Program.cs
+++ b/src/ResponsibleGherkin/Program.cs
@@ -1,7 +1,10 @@
 ﻿using System.CommandLine;
+using System.CommandLine.Invocation;
 using System.CommandLine.IO;
 using System.Diagnostics.CodeAnalysis;
 using System.IO.Abstractions;
+using Gherkin;
+using Gherkin.Ast;
 
 namespace ResponsibleGherkin;
 
@@ -26,6 +29,27 @@ public static class Program
 		};
 
 		rootCommand.Name = "responsible-gherkin";
+
+		rootCommand.SetHandler(
+			(string inputFile,
+				InvocationContext ctx) =>
+			{
+				try
+				{
+					GherkinDocument document;
+					using (var fileReader = fileSystem.File.OpenText(inputFile))
+					{
+						document = new Parser { StopAtFirstError = true }.Parse(fileReader);
+					}
+
+					CodeGenerator.GenerateFile(document.Feature, default, default);
+				}
+				catch (IOException exception)
+				{
+					ctx.Console.Error.WriteLine($"Could not read input: {exception.Message}");
+				}
+			},
+			inputFileArgument);
 
 		return rootCommand;
 	}

--- a/src/ResponsibleGherkin/Program.cs
+++ b/src/ResponsibleGherkin/Program.cs
@@ -10,6 +10,20 @@ namespace ResponsibleGherkin;
 
 public static class Program
 {
+	private const string CommandName = "responsible-gherkin";
+	private const string ConfigureName = "configure";
+	private const string GenerateName = "generate";
+
+	private const string MainDescription =
+		$@"Generate Responsible test case stubs from Gherkin specifications.
+
+First generate a configuration using
+    {CommandName} {ConfigureName} ...
+
+store it to a file, and then generate your code using
+    {CommandName} {GenerateName} ...
+";
+
 	// This only binds the root command invocation to the real file system and console.
 	// I.e. deals only with non-testable parts.
 	[ExcludeFromCodeCoverage]
@@ -19,14 +33,13 @@ public static class Program
 
 	public static RootCommand BuildRootCommand(IFileSystem fileSystem)
 	{
-		var rootCommand = new RootCommand(
-			"Generate Responsible test case stubs from Gherkin specifications.")
+		var rootCommand = new RootCommand(MainDescription)
 		{
 			ConfigureCommand(),
 			GenerateCommand(fileSystem),
 		};
 
-		rootCommand.Name = "responsible-gherkin";
+		rootCommand.Name = CommandName;
 		rootCommand.TreatUnmatchedTokensAsErrors = true;
 
 		return rootCommand;
@@ -34,11 +47,68 @@ public static class Program
 
 	private static Command ConfigureCommand()
 	{
-		var flavorOption = new Option<FlavorType>(
-			new[] { "--flavor", "-f" },
-			"Flavor of code to generate.");
+		var flavorArgument = new Argument<FlavorType>(
+			"flavor",
+			"Flavor of code generation");
 
-		var command = new Command("configure", "Generate configuration file");
+		var namespaceArgument = new Argument<string>(
+			"namespace",
+			"Namespace to put classes in");
+
+		var baseClassArgument = new Argument<string>(
+			"base-class",
+			"Base class to derive from");
+
+		var executorArgument = new Argument<string>(
+			"executor",
+			"Name of parameter that has the TestInstructionExecutor");
+
+		var indentTypeArgument = new Argument<IndentType>(
+			"indent-type",
+			"Type of indentation to use");
+
+		var indentAmountArgument = new Argument<int>(
+			"indent-amount",
+			"Amount of indentation to use");
+
+		var command = new Command(
+			ConfigureName,
+			$"Generate a configuration to be used with {GenerateName}")
+		{
+			flavorArgument,
+			namespaceArgument,
+			baseClassArgument,
+			executorArgument,
+			indentTypeArgument,
+			indentAmountArgument,
+		};
+
+		command.SetHandler((
+				FlavorType flavor,
+				string @namespace,
+				string baseClass,
+				string executorName,
+				IndentType indentType,
+				int indentAmount,
+				InvocationContext invocationContext) =>
+			{
+				var configuration = new Configuration(
+					flavor,
+					new IndentInfo(indentAmount, indentType),
+					@namespace,
+					baseClass,
+					executorName);
+
+				invocationContext.Console.Out.WriteLine(JsonSerializer.Serialize(
+					configuration, new JsonSerializerOptions { WriteIndented = true }));
+			},
+			flavorArgument,
+			namespaceArgument,
+			baseClassArgument,
+			executorArgument,
+			indentTypeArgument,
+			indentAmountArgument);
+
 		return command;
 	}
 
@@ -46,25 +116,24 @@ public static class Program
 	{
 		var configFileArgument = new Argument<string>(
 			"config",
-			"Path to configuration file to use.");
+			"Path to configuration file to use");
 
 		var inputFileArgument = new Argument<string>(
 			"input",
-			"Input feature file to generate code from.");
+			"Input feature file to generate code from");
 
 		var outputDirectoryArgument = new Argument<string>(
 			"output",
-			"Directory to write content into.");
+			"Directory to write content into");
 
-		var generateCommand = new Command("generate", "Generate test case stubs")
+		var generateCommand = new Command(GenerateName, "Generate test case stubs")
 		{
 			configFileArgument,
 			inputFileArgument,
 			outputDirectoryArgument,
 		};
 
-		generateCommand.SetHandler(
-			(
+		generateCommand.SetHandler((
 				string configFile,
 				string inputFile,
 				string outputDirectory,

--- a/src/ResponsibleGherkin/ResponsibleGherkin.csproj
+++ b/src/ResponsibleGherkin/ResponsibleGherkin.csproj
@@ -2,6 +2,8 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
+        <PackAsTool>true</PackAsTool>
+        <ToolCommandName>responsible-gherkin</ToolCommandName>
         <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
@@ -23,6 +25,9 @@
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
+      <PackageReference Include="System.CommandLine" Version="2.0.0-beta3.22114.1" />
+      <PackageReference Include="System.IO.Abstractions" Version="16.1.25" />
+      <PackageReference Include="System.Text.Json" Version="6.0.3" />
     </ItemGroup>
 
 </Project>

--- a/src/ResponsibleGherkin/ScenarioGenerator.cs
+++ b/src/ResponsibleGherkin/ScenarioGenerator.cs
@@ -7,12 +7,12 @@ public static class ScenarioGenerator
 	public static IEnumerable<Line> Generate(
 		Scenario scenario,
 		Flavor flavor,
-		GenerationContext context)
+		Configuration configuration)
 	{
 		yield return $"[{flavor.TestAttribute}]";
 
 		var methodName = $"{scenario.Keyword.Trim()}_{scenario.Name.ToPascalCase()}";
-		yield return $"public {flavor.ReturnType} {methodName}() => this.{context.ExecutorName}.{flavor.RunMethod}(";
+		yield return $"public {flavor.ReturnType} {methodName}() => this.{configuration.ExecutorName}.{flavor.RunMethod}(";
 
 		yield return GenerateScenario(scenario).IndentBy(1);
 


### PR DESCRIPTION
Also migrates `ResponsibleGherkin.Tests` to Xunit, which seems to work better with nullable reference types.