### PR TITLE
Optimize Stryker runs

### DIFF
--- a/src/ResponsibleGherkin.Tests/stryker-config.json
+++ b/src/ResponsibleGherkin.Tests/stryker-config.json
@@ -15,6 +15,8 @@
             "low": 100,
             "break": 100
         },
-        "mutation-level": "Standard"
+        "mutation-level": "Standard",
+        "test-case-filter": "FullyQualifiedName!~CodeGeneratorCompilationTests",
+        "additional-timeout": 10000
     }
 }


### PR DESCRIPTION
Skip slow compilation tests (they aren't needed for 100% mutation score), increase timeout limit a bit to prevent timeouts.