### PR TITLE
responsible-gherkin: Fix over-picky identifier validation

### DIFF
--- a/src/ResponsibleGherkin.Tests/CommentParserTests.cs
+++ b/src/ResponsibleGherkin.Tests/CommentParserTests.cs
@@ -14,9 +14,9 @@ public class CommentParserTests
 	[InlineData("# responsible-indent: 4spaces")]
 	[InlineData("# responsible-indent: 1 foo")]
 	[InlineData("# responsible-indent: foo tabs")]
-	[InlineData("# responsible-namespace: ...")]
-	[InlineData("# responsible-base-class: base class")]
-	[InlineData("# responsible-executor: 123")]
+	[InlineData("# responsible-namespace:    ")]
+	[InlineData("# responsible-base-class: \t ")]
+	[InlineData("# responsible-executor:")]
 	public void Parse_ThrowsError_OnInvalidValues(string comment)
 	{
 		var parse = () => ParseSingleLine(comment);
@@ -53,6 +53,16 @@ public class CommentParserTests
 	public void Parse_ParsesIndentInfo_WhenValid(string input, int expectedAmount, char expectedChar) =>
 		ParseSingleLine(input)
 			.IndentInfo.Should().BeEquivalentTo(new IndentInfo(expectedAmount, expectedChar));
+
+	[Theory]
+	[InlineData("# responsible-namespace: My.Nested. Namespace")]
+	[InlineData("# responsible-executor: GetContext().Executor")]
+	[InlineData("# responsible-base-class: Some.Other.Namespace.BaseClass")]
+	public void Parse_DoesNotThrow_WhenNamesAreValid(string input)
+	{
+		var parse = () => ParseSingleLine(input);
+		parse.Should().NotThrow("the input is valid");
+	}
 
 	[Fact]
 	public void FullConfiguration_CanBeBuiltFromComments()

--- a/src/ResponsibleGherkin/CommentParser.cs
+++ b/src/ResponsibleGherkin/CommentParser.cs
@@ -1,6 +1,5 @@
 using System.Globalization;
 using Gherkin.Ast;
-using Microsoft.CodeAnalysis.CSharp;
 
 namespace ResponsibleGherkin;
 
@@ -28,13 +27,13 @@ public static class CommentParser
 			TryParse("responsible-indent:", comment, content, ref indentInfo, TryParseIndentInfo);
 
 		void ParseNamespace(Comment comment, string content) =>
-			TryParse("responsible-namespace:", comment, content, ref @namespace, TryParseIdentifier);
+			TryParse("responsible-namespace:", comment, content, ref @namespace, TryParseIdentifierOrExpression);
 
 		void ParseBaseClass(Comment comment, string content) =>
-			TryParse("responsible-base-class:", comment, content, ref baseClass, TryParseIdentifier);
+			TryParse("responsible-base-class:", comment, content, ref baseClass, TryParseIdentifierOrExpression);
 
 		void ParseExecutorName(Comment comment, string content) =>
-			TryParse("responsible-executor:", comment, content, ref executorName, TryParseIdentifier);
+			TryParse("responsible-executor:", comment, content, ref executorName, TryParseIdentifierOrExpression);
 
 		var parsers = new Action<Comment, string>[]
 		{
@@ -117,8 +116,10 @@ public static class CommentParser
 			? result
 			: null;
 
-	private static string? TryParseIdentifier(this string input) =>
-		SyntaxFacts.IsValidIdentifier(input) ? input : null;
+	// Let's not try to be too smart. The compiler will reveal if it's wrong sooner or later.
+	// Just checking for empty is good enough for now.
+	private static string? TryParseIdentifierOrExpression(this string input) =>
+		string.IsNullOrEmpty(input) ? null : input;
 
 	private static string ExtractContent(Comment comment) => comment.Text.Trim(LineTrimChars);
 


### PR DESCRIPTION
It didn't allow stuff that was valid, but I just didn't think about. We don't really need to be that strict.