### PR TITLE
Add RunAsSimulatedUpdateLoop and RunAsLoop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and thus not under semantic versioning.
 ## [Unreleased]
 
 ### Added
-- `RunAsLoop` operator, for running test instructions synchronously as a run loop.
+- `RunAsLoop` operator, for running test instructions synchronously as a loop with a tick callback.
 
 ### Changed
 - Include hint in state strings about being able to provide extra context to wait conditions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and thus not under semantic versioning.
 
 ## [Unreleased]
 
+### Added
+- `RunAsLoop` operator, for running test instructions synchronously as a run loop.
+
 ### Changed
 - Include hint in state strings about being able to provide extra context to wait conditions
 - Improve exception message handling by not truncating long messages (I don't remember why I did this originally)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and thus not under semantic versioning.
 ## [Unreleased]
 
 ### Added
-- `RunAsLoop` operator, for running test instructions synchronously as a loop with a tick callback.
+- `RunAsLoop` and `RunAsSimulatedUpdateLoop` operators, for running test instructions synchronously as a loop with a tick callback.
 
 ### Changed
 - Include hint in state strings about being able to provide extra context to wait conditions

--- a/com.beatwaves.responsible/Runtime/TestInstruction.cs
+++ b/com.beatwaves.responsible/Runtime/TestInstruction.cs
@@ -198,6 +198,7 @@ namespace Responsible
 		/// <summary>
 		/// Synchronously executes a test instruction by repeatedly calling a callback,
 		/// until the instruction has completed successfully or with an error.
+		/// The provided callback will be executed before any conditions are polled.
 		/// </summary>
 		/// <param name="instruction">Instruction to run in a run loop.</param>
 		/// <param name="runOneIteration">Action to run for each iteration of the loop.</param>

--- a/com.beatwaves.responsible/Runtime/TestInstruction.cs
+++ b/com.beatwaves.responsible/Runtime/TestInstruction.cs
@@ -218,7 +218,7 @@ namespace Responsible
 			{
 				var task = executor.RunInstruction(
 					instruction.CreateState(),
-					new SourceContext(nameof(ToTask), memberName, sourceFilePath, sourceLineNumber),
+					new SourceContext(nameof(RunAsLoop), memberName, sourceFilePath, sourceLineNumber),
 					cancellationToken);
 
 				while (!task.IsCompleted)

--- a/com.beatwaves.responsible/Runtime/TestInstruction.cs
+++ b/com.beatwaves.responsible/Runtime/TestInstruction.cs
@@ -198,17 +198,18 @@ namespace Responsible
 		/// <summary>
 		/// Synchronously executes a test instruction by repeatedly calling a callback,
 		/// until the instruction has completed successfully or with an error.
-		/// The provided callback will be executed before any conditions are polled.
+		/// The provided callback will be executed before any conditions are polled,
+		/// and should run any actions required for the instruction to complete.
 		/// </summary>
-		/// <param name="instruction">Instruction to run in a run loop.</param>
-		/// <param name="runOneIteration">Action to run for each iteration of the loop.</param>
+		/// <param name="instruction">Instruction to run.</param>
+		/// <param name="tick">Action to run for each iteration of the loop.</param>
 		/// <param name="cancellationToken">Optional cancellation token to cancel the instruction prematurely.</param>
 		/// <typeparam name="T">Return type of the instruction to execute.</typeparam>
 		/// <returns>The result of the test instruction, if it completes successfully.</returns>
 		/// <inheritdoc cref="Docs.Inherit.CallerMember{T1,T2, T3}"/>
 		public static T RunAsLoop<T>(
 			this ITestInstruction<T> instruction,
-			Action runOneIteration,
+			Action tick,
 			CancellationToken cancellationToken = default,
 			[CallerMemberName] string memberName = "",
 			[CallerFilePath] string sourceFilePath = "",
@@ -224,7 +225,7 @@ namespace Responsible
 
 				while (!task.IsCompleted)
 				{
-					scheduler.Run(runOneIteration);
+					scheduler.Run(tick);
 				}
 
 				return task.GetAwaiter().GetResult();

--- a/com.beatwaves.responsible/Runtime/Utilities/GenericRunLoopScheduler.cs
+++ b/com.beatwaves.responsible/Runtime/Utilities/GenericRunLoopScheduler.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Responsible.Utilities
+{
+	/// <summary>
+	/// Generic version of a run-loop scheduler, which does not simulate time.
+	/// </summary>
+	internal sealed class GenericRunLoopScheduler : RunLoopScheduler<object>
+	{
+		protected override void Tick(Action<object> tick) => tick(Unit.Instance);
+
+		public override DateTimeOffset TimeNow => DateTimeOffset.Now;
+	}
+}

--- a/com.beatwaves.responsible/Runtime/Utilities/GenericRunLoopScheduler.cs.meta
+++ b/com.beatwaves.responsible/Runtime/Utilities/GenericRunLoopScheduler.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: b9932dafaf0349e5b8dd6d3b9bbf6545
+timeCreated: 1654534783

--- a/com.beatwaves.responsible/Runtime/Utilities/RunLoopScheduler.cs
+++ b/com.beatwaves.responsible/Runtime/Utilities/RunLoopScheduler.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Responsible.Utilities
+{
+	internal class RunLoopScheduler : ITestScheduler
+	{
+		private readonly RunLoopExceptionSource runLoopExceptionSource = new RunLoopExceptionSource();
+		private readonly RetryingPoller poller = new RetryingPoller();
+		private int frameNow;
+
+		public IExternalResultSource ExternalResultSource => this.runLoopExceptionSource;
+
+		public void Run(Action runOneIteration)
+		{
+			try
+			{
+				runOneIteration();
+				this.poller.Poll();
+				++this.frameNow;
+			}
+			catch (Exception e)
+			{
+				this.runLoopExceptionSource.SetException(e);
+			}
+		}
+
+		int ITestScheduler.FrameNow => this.frameNow;
+		DateTimeOffset ITestScheduler.TimeNow => DateTimeOffset.Now;
+
+		IDisposable ITestScheduler.RegisterPollCallback(Action action) =>
+			this.poller.RegisterPollCallback(action);
+
+		private class RunLoopExceptionSource : IExternalResultSource
+		{
+			private Action<Exception> abortCurrentInstructionAction;
+
+			public void SetException(Exception exception)
+			{
+				// This is essentially guaranteed to not be null, so don't check it explicitly.
+				this.abortCurrentInstructionAction(exception);
+			}
+
+			Task<T> IExternalResultSource.GetExternalResult<T>(CancellationToken cancellationToken)
+			{
+				var completionSource = new TaskCompletionSource<T>(cancellationToken);
+				this.abortCurrentInstructionAction = completionSource.SetException;
+				return completionSource.Task;
+			}
+		}
+	}
+}

--- a/com.beatwaves.responsible/Runtime/Utilities/RunLoopScheduler.cs
+++ b/com.beatwaves.responsible/Runtime/Utilities/RunLoopScheduler.cs
@@ -34,18 +34,18 @@ namespace Responsible.Utilities
 
 		private class RunLoopExceptionSource : IExternalResultSource
 		{
-			private Action<Exception> abortCurrentInstructionAction;
+			private Action<Exception> abortCurrentInstruction;
 
 			public void SetException(Exception exception)
 			{
 				// This is essentially guaranteed to not be null, so don't check it explicitly.
-				this.abortCurrentInstructionAction(exception);
+				this.abortCurrentInstruction(exception);
 			}
 
 			Task<T> IExternalResultSource.GetExternalResult<T>(CancellationToken cancellationToken)
 			{
 				var completionSource = new TaskCompletionSource<T>(cancellationToken);
-				this.abortCurrentInstructionAction = completionSource.SetException;
+				this.abortCurrentInstruction = completionSource.SetException;
 				return completionSource.Task;
 			}
 		}

--- a/com.beatwaves.responsible/Runtime/Utilities/RunLoopScheduler.cs
+++ b/com.beatwaves.responsible/Runtime/Utilities/RunLoopScheduler.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 
 namespace Responsible.Utilities
 {
-	internal class RunLoopScheduler : ITestScheduler
+	internal abstract class RunLoopScheduler<TTickArgument> : ITestScheduler
 	{
 		private readonly RunLoopExceptionSource runLoopExceptionSource = new RunLoopExceptionSource();
 		private readonly RetryingPoller poller = new RetryingPoller();
@@ -12,11 +12,11 @@ namespace Responsible.Utilities
 
 		public IExternalResultSource ExternalResultSource => this.runLoopExceptionSource;
 
-		public void Run(Action runOneIteration)
+		public void Run(Action<TTickArgument> tick)
 		{
 			try
 			{
-				runOneIteration();
+				this.Tick(tick);
 				this.poller.Poll();
 				++this.frameNow;
 			}
@@ -26,8 +26,10 @@ namespace Responsible.Utilities
 			}
 		}
 
+		protected abstract void Tick(Action<TTickArgument> tick);
+		public abstract DateTimeOffset TimeNow { get; }
+
 		int ITestScheduler.FrameNow => this.frameNow;
-		DateTimeOffset ITestScheduler.TimeNow => DateTimeOffset.Now;
 
 		IDisposable ITestScheduler.RegisterPollCallback(Action action) =>
 			this.poller.RegisterPollCallback(action);

--- a/com.beatwaves.responsible/Runtime/Utilities/RunLoopScheduler.cs.meta
+++ b/com.beatwaves.responsible/Runtime/Utilities/RunLoopScheduler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fc85ae0cdd98b4d0dbdac1253408f08f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.beatwaves.responsible/Runtime/Utilities/SimulatedUpdateLoopScheduler.cs
+++ b/com.beatwaves.responsible/Runtime/Utilities/SimulatedUpdateLoopScheduler.cs
@@ -8,7 +8,8 @@ namespace Responsible.Utilities
 		private DateTimeOffset timeNow = DateTimeOffset.Now;
 
 		public SimulatedUpdateLoopScheduler(double framesPerSecond) =>
-			this.frameDuration = TimeSpan.FromSeconds(1 / framesPerSecond);
+			// On Unity (and older .NET), FromSeconds discards sub-millisecond information
+			this.frameDuration = TimeSpan.FromTicks((int)Math.Round(TimeSpan.TicksPerSecond / framesPerSecond));
 
 		protected override void Tick(Action<TimeSpan> tick)
 		{

--- a/com.beatwaves.responsible/Runtime/Utilities/SimulatedUpdateLoopScheduler.cs
+++ b/com.beatwaves.responsible/Runtime/Utilities/SimulatedUpdateLoopScheduler.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace Responsible.Utilities
+{
+	internal class SimulatedUpdateLoopScheduler : RunLoopScheduler<TimeSpan>
+	{
+		private readonly TimeSpan frameDuration;
+		private DateTimeOffset timeNow = DateTimeOffset.Now;
+
+		public SimulatedUpdateLoopScheduler(double framesPerSecond) =>
+			this.frameDuration = TimeSpan.FromSeconds(1 / framesPerSecond);
+
+		protected override void Tick(Action<TimeSpan> tick)
+		{
+			tick(this.frameDuration);
+			this.timeNow += this.frameDuration;
+		}
+
+		public override DateTimeOffset TimeNow => this.timeNow;
+	}
+}

--- a/com.beatwaves.responsible/Runtime/Utilities/SimulatedUpdateLoopScheduler.cs.meta
+++ b/com.beatwaves.responsible/Runtime/Utilities/SimulatedUpdateLoopScheduler.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 0c806cde751343cea224f960c2389cb5
+timeCreated: 1654535174

--- a/com.beatwaves.responsible/Runtime/Utilities/Unit.cs
+++ b/com.beatwaves.responsible/Runtime/Utilities/Unit.cs
@@ -6,6 +6,6 @@ namespace Responsible.Utilities
 		{
 		}
 
-		public static object Instance => new Unit();
+		public static object Instance { get; } = new Unit();
 	}
 }

--- a/docfx/design.md
+++ b/docfx/design.md
@@ -58,8 +58,8 @@ as an asynchronous task using the `ToTask` extension method.
 On Unity you can also use the `ToYieldInstruction` extension method,
 to get a yield instruction for a `[UnityTest]` play mode test.
 Additionally, the
-[`RunAsSimulatedUpdateLoop`](xref:TestInstruction.RunAsSimulatedUpdateLoop)
-and [`RunAsLoop`](xref:TestInstruction.RunAsLoop)
+[`RunAsSimulatedUpdateLoop`](xref:Responsible.TestInstruction.RunAsSimulatedUpdateLoop)
+and [`RunAsLoop`](xref:Responsible.TestInstruction.RunAsLoop)
 operators can be used to synchronously run instructions in a loop,
 using a user-provided tick callback to simulate step-by-step updates.
 

--- a/docfx/design.md
+++ b/docfx/design.md
@@ -57,9 +57,7 @@ Instructions can be executed by a
 as an asynchronous task using the `ToTask` extension method.
 On Unity you can also use the `ToYieldInstruction` extension method,
 to get a yield instruction for a `[UnityTest]` play mode test.
-Additionally, the
-[`RunAsSimulatedUpdateLoop`](xref:Responsible.TestInstruction.RunAsSimulatedUpdateLoop)
-and [`RunAsLoop`](xref:Responsible.TestInstruction.RunAsLoop)
+Additionally, the `RunAsSimulatedUpdateLoop` and `RunAsLoop`
 operators can be used to synchronously run instructions in a loop,
 using a user-provided tick callback to simulate step-by-step updates.
 

--- a/docfx/design.md
+++ b/docfx/design.md
@@ -44,18 +44,25 @@ as you don't need separate overloads for operations returning values and operati
 Because all the operation interfaces are covariant,
 you can easily use a more derived operation where a less derived type is required.
 However, if you are working with value types,
-you may need to use the `BoxResult` operator, to convert the type to `object`.
+you may need to use the `BoxResult` operator to convert the type to `object`.
 
 ### Instructions
 
 Instructions are represented by the
 [`ITestInstruction<T>`](xref:Responsible.ITestInstruction`1) interface.
 They represent a synchronous or asynchronous operation producing a single result.
+
 Instructions can be executed by a
 [`TestInstructionExecutor`](xref:Responsible.TestInstructionExecutor)
 as an asynchronous task using the `ToTask` extension method.
-On Unity you cal also use the `ToYieldInstruction` extension method,
+On Unity you can also use the `ToYieldInstruction` extension method,
 to get a yield instruction for a `[UnityTest]` play mode test.
+Additionally, the
+[`RunAsSimulatedUpdateLoop`](xref:TestInstruction.RunAsSimulatedUpdateLoop)
+and [`RunAsLoop`](xref:TestInstruction.RunAsLoop)
+operators can be used to synchronously run instructions in a loop,
+using a user-provided tick callback to simulate step-by-step updates.
+
 All instructions should have an internal timeout.
 The basic operations for chaining instructions are `ContinueWith` and `Sequence`.
 See [`TestInstruction`](xref:Responsible.TestInstruction) for all extension methods.
@@ -118,7 +125,7 @@ While Responsible is already useful on it's own, it is built to be extensible,
 and becomes even more powerful when you write your own operators on top of it.
 It's recommended to build your own wait conditions and instructions for common use cases
 by wrapping or combining the basic operations.
-You could e.g. create a method with the following signature:  
+You could e.g. create a method with the following signature:
 `ITestWaitCondition<GameObject> WaitForDescendantByNameToBeActive(GameObject gameObject, string name)`.
 
 You may want to pass in explicit `CallerMemberName` etc. arguments to your own low-level operations
@@ -155,7 +162,7 @@ everything is expected to happen in a single thread.
 If the method names in the [`Responsibly`](xref:Responsible.Responsibly)
 class do not conflict with anything else,
 using `using static Responsible.Responsibly;` can make your code more concise.
-The method names were designed to work well like this. 
+The method names were designed to work well like this.
 
 All the basic operations (excluding optional responders) implement the
 `ITestOperation<T>` interface, which contains the `CreateState` method,
@@ -180,7 +187,7 @@ var waitForQuux = WaitForQuux(...);
 
 var waitForFooAndBar = waitForFoo.AndThen(waitForBar);
 var waitForFooAndQuux = waitForFoo.AndThen(waitForQuux);
-``` 
+```
 Here, `waitForFoo` is being reused in two different contexts,
 and reusing e.g. `waitForFooAndBar` later is also fine.
 What happens under the hood, is that for each *execution* of an operation,

--- a/src/.config/dotnet-tools.json
+++ b/src/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "jetbrains.resharper.globaltools": {
-      "version": "2022.1.0-eap10",
+      "version": "2022.1.1",
       "commands": [
         "jb"
       ]

--- a/src/Responsible.Tests/RunAsLoopTests.cs
+++ b/src/Responsible.Tests/RunAsLoopTests.cs
@@ -23,7 +23,7 @@ namespace Responsible.Tests
 		}
 
 		[Test]
-		public void RunAsLoop_ThrowsTestFailureException_WhenTimedOut()
+		public void RunAsLoop_ThrowsProperException_WhenTimedOut()
 		{
 			var exception = Assert.Throws<TestFailureException>(() => Responsibly
 				.WaitForCondition("Never", () => false)
@@ -31,10 +31,11 @@ namespace Responsible.Tests
 				.RunAsLoop(() => { }));
 
 			Assert.IsInstanceOf<TimeoutException>(exception?.InnerException);
+			AssertMessageContainsOperationNameTag(exception);
 		}
 
 		[Test]
-		public void RunAsLoop_ThrowsTestFailureException_WhenInstructionThrows()
+		public void RunAsLoop_ThrowsProperException_WhenInstructionThrows()
 		{
 			var exception = Assert.Throws<TestFailureException>(() => Responsibly
 				.WaitForCondition(
@@ -44,10 +45,11 @@ namespace Responsible.Tests
 				.RunAsLoop(() => { }));
 
 			Assert.AreEqual(TestExceptionMessage, exception?.InnerException?.Message);
+			AssertMessageContainsOperationNameTag(exception);
 		}
 
 		[Test]
-		public void RunAsLoop_ThrowsTestFailureException_WhenRunLoopThrows()
+		public void RunAsLoop_ThrowsProperException_WhenRunLoopThrows()
 		{
 			var exception = Assert.Throws<TestFailureException>(() => Responsibly
 				.WaitForCondition("Never", () => false)
@@ -55,6 +57,12 @@ namespace Responsible.Tests
 				.RunAsLoop(() => throw new Exception(TestExceptionMessage)));
 
 			Assert.AreEqual(TestExceptionMessage, exception?.InnerException?.Message);
+			// Can't (currently, easily) get the current instruction from this to include the instruction stack
 		}
+
+		private static void AssertMessageContainsOperationNameTag(TestFailureException exception) =>
+			StringAssert.Contains(
+				$"[{nameof(TestInstruction.RunAsLoop)}]",
+				exception.Message);
 	}
 }

--- a/src/Responsible.Tests/RunAsLoopTests.cs
+++ b/src/Responsible.Tests/RunAsLoopTests.cs
@@ -1,0 +1,60 @@
+using System;
+using NUnit.Framework;
+
+namespace Responsible.Tests
+{
+	public class RunAsLoopTests
+	{
+		private const string TestExceptionMessage = "Test exception";
+
+		[Test]
+		public void RunAsLoop_CompletesWithExpectedValue()
+		{
+			var frame = 0;
+			var result = Responsibly
+				.WaitForConditionOn(
+					"Frame to be 10",
+					() => frame,
+					f => f == 10)
+				.ExpectWithinSeconds(1)
+				.RunAsLoop(() => ++frame);
+
+			Assert.AreEqual(10, result);
+		}
+
+		[Test]
+		public void RunAsLoop_ThrowsTestFailureException_WhenTimedOut()
+		{
+			var exception = Assert.Throws<TestFailureException>(() => Responsibly
+				.WaitForCondition("Never", () => false)
+				.ExpectWithinSeconds(0)
+				.RunAsLoop(() => { }));
+
+			Assert.IsInstanceOf<TimeoutException>(exception?.InnerException);
+		}
+
+		[Test]
+		public void RunAsLoop_ThrowsTestFailureException_WhenInstructionThrows()
+		{
+			var exception = Assert.Throws<TestFailureException>(() => Responsibly
+				.WaitForCondition(
+					"Throw",
+					() => throw new Exception(TestExceptionMessage))
+				.ExpectWithinSeconds(1)
+				.RunAsLoop(() => { }));
+
+			Assert.AreEqual(TestExceptionMessage, exception?.InnerException?.Message);
+		}
+
+		[Test]
+		public void RunAsLoop_ThrowsTestFailureException_WhenRunLoopThrows()
+		{
+			var exception = Assert.Throws<TestFailureException>(() => Responsibly
+				.WaitForCondition("Never", () => false)
+				.ExpectWithinSeconds(1)
+				.RunAsLoop(() => throw new Exception(TestExceptionMessage)));
+
+			Assert.AreEqual(TestExceptionMessage, exception?.InnerException?.Message);
+		}
+	}
+}

--- a/src/Responsible.Tests/RunAsLoopTests.cs
+++ b/src/Responsible.Tests/RunAsLoopTests.cs
@@ -12,8 +12,7 @@ namespace Responsible.Tests
 		[Test]
 		public void RunAsSimulatedUpdateLoop_UsesSimulatedFrameDurationForTime()
 		{
-			// First poll happens at time zero, so we ignore the first increment
-			var frameCount = -1;
+			var frameCount = 0;
 			TimeSpan frameDuration = default;
 
 			_ = Responsibly
@@ -26,7 +25,8 @@ namespace Responsible.Tests
 						frameDuration = duration;
 					});
 
-			Assert.AreEqual(TimeSpan.FromSeconds(1.0 / 60), frameDuration);
+			// On Unity (and older .NET), FromSeconds discards sub-millisecond information
+			Assert.AreEqual(TimeSpan.FromTicks((int)Math.Round(TimeSpan.TicksPerSecond / 60.0)), frameDuration);
 			Assert.AreEqual(60, frameCount);
 		}
 

--- a/src/Responsible.Tests/RunAsLoopTests.cs
+++ b/src/Responsible.Tests/RunAsLoopTests.cs
@@ -1,5 +1,7 @@
 using System;
 using NUnit.Framework;
+using Responsible.Tests.Utilities;
+using static Responsible.Responsibly;
 
 namespace Responsible.Tests
 {
@@ -20,6 +22,21 @@ namespace Responsible.Tests
 				.RunAsLoop(() => ++frame);
 
 			Assert.AreEqual(10, result);
+		}
+
+		[Test]
+		public void RunLoopFrameCount_ContainsExpectedValues()
+		{
+			var frame = -1;
+			var exception = Assert.Throws<TestFailureException>(() => Responsibly
+				.WaitForCondition("frame", () => frame == 10)
+				.ExpectWithinSeconds(1)
+				.ContinueWith(Do("Throw", () => throw new Exception()))
+				.RunAsLoop(() => ++frame));
+
+			StateAssert.StringContainsInOrder(exception?.Message)
+				.Completed("frame")
+				.Details("≈ 10 frames");
 		}
 
 		[Test]

--- a/src/Responsible.Tests/RunAsLoopTests.cs
+++ b/src/Responsible.Tests/RunAsLoopTests.cs
@@ -10,6 +10,27 @@ namespace Responsible.Tests
 		private const string TestExceptionMessage = "Test exception";
 
 		[Test]
+		public void RunAsSimulatedUpdateLoop_UsesSimulatedFrameDurationForTime()
+		{
+			// First poll happens at time zero, so we ignore the first increment
+			var frameCount = -1;
+			TimeSpan frameDuration = default;
+
+			_ = Responsibly
+				.WaitForSeconds(1)
+				.RunAsSimulatedUpdateLoop(
+					60,
+					duration =>
+					{
+						++frameCount;
+						frameDuration = duration;
+					});
+
+			Assert.AreEqual(TimeSpan.FromSeconds(1.0 / 60), frameDuration);
+			Assert.AreEqual(60, frameCount);
+		}
+
+		[Test]
 		public void RunAsLoop_CompletesWithExpectedValue()
 		{
 			var frame = 0;

--- a/src/Responsible.Tests/RunAsLoopTests.cs.meta
+++ b/src/Responsible.Tests/RunAsLoopTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 175e881d445a3439aab24dc15ac8c2bf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This could be useful for using Responsible in contexts where you want to mock frame-by-frame updates running faster than real time.