### PR TITLE
Bump versions to 4.4.0 and 0.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and thus not under semantic versioning.
 
 ## [Unreleased]
 
+## [4.4.0] - 2023-03-23
+
 ### Added
 - `RunAsLoop` and `RunAsSimulatedUpdateLoop` operators, for running test instructions synchronously as a loop with a tick callback.
 - `Repeatedly` operator, which turns a test responder into an optional responder that executes repeatedly.
@@ -142,7 +144,8 @@ and thus not under semantic versioning.
 ### Added
 - Initial public release with basic functionality.
 
-[Unreleased]: https://github.com/sbergen/Responsible/compare/v4.3.0...HEAD
+[Unreleased]: https://github.com/sbergen/Responsible/compare/v4.4.0...HEAD
+[4.4.0]: https://github.com/sbergen/Responsible/releases/tag/v4.4.0
 [4.3.0]: https://github.com/sbergen/Responsible/releases/tag/v4.3.0
 [4.2.0]: https://github.com/sbergen/Responsible/releases/tag/v4.2.0
 [4.1.2]: https://github.com/sbergen/Responsible/releases/tag/v4.1.2

--- a/com.beatwaves.responsible/Runtime/Responsible.csproj
+++ b/com.beatwaves.responsible/Runtime/Responsible.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <PackageId>Beatwaves.Responsible</PackageId>
-        <Version>4.3.0</Version>
+        <Version>4.4.0</Version>
         <Authors>Sakari Bergen</Authors>
         <PackageTags>test;automation;testing;reactive;asynchronous</PackageTags>
         <PackageProjectUrl>https://www.beatwaves.net/Responsible/</PackageProjectUrl>

--- a/com.beatwaves.responsible/package.json
+++ b/com.beatwaves.responsible/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.beatwaves.responsible",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "displayName": "Responsible",
   "description": "Reactive asynchronous automated testing utility to enhance the Unity Test Runner.\nProvides a framework for constructing asynchronous\n- wait conditions,\n- test instructions,\n- and responders, which execute an instruction when a condition is met\nAlso includes utilities for combining and chaining all of the above.",
   "unity": "2019.4",

--- a/src/ResponsibleGherkin/ResponsibleGherkin.csproj
+++ b/src/ResponsibleGherkin/ResponsibleGherkin.csproj
@@ -8,7 +8,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <PackageId>Beatwaves.ResponsibleGherkin</PackageId>
-        <Version>0.0.3</Version>
+        <Version>0.0.4</Version>
         <Authors>Sakari Bergen</Authors>
         <PackageTags>BDD;test;automation;testing</PackageTags>
         <PackageProjectUrl>https://www.beatwaves.net/Responsible/</PackageProjectUrl>


### PR DESCRIPTION
This release is long overdue, as it fixes some Unity 2021 issues - I just haven't remembered to do it.