### PR TITLE
Add Unity activation workflow (manually run)

### DIFF
--- a/.github/workflows/unity-activation.yml
+++ b/.github/workflows/unity-activation.yml
@@ -1,0 +1,18 @@
+name: Acquire Unity activation file
+on:
+  workflow_dispatch: {}
+jobs:
+  activation:
+    name: Request manual activation file
+    runs-on: ubuntu-latest
+    steps:
+      # Request manual activation file
+      - name: Request manual activation file
+        id: getManualLicenseFile
+        uses: game-ci/unity-request-activation-file@v2
+      # Upload artifact (Unity_v20XX.X.XXXX.alf)
+      - name: Expose as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ steps.getManualLicenseFile.outputs.filePath }}
+          path: ${{ steps.getManualLicenseFile.outputs.filePath }}


### PR DESCRIPTION
To set up Dependabot secrets, I need this again. Don't know why I didn't keep it around the last time I did this 🤔 