### PR TITLE
Actions secrets: use UNITY_LICENSE

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -43,7 +43,7 @@ jobs:
         id: tests
         uses: game-ci/unity-test-runner@v2
         env:
-          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE_2020 }}
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
         with:
           projectPath: ResponsibleUnity
           unityVersion: ${{ matrix.unityVersion }}

--- a/.github/workflows/releasables.yml
+++ b/.github/workflows/releasables.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Generate docs
         uses: game-ci/unity-builder@v2
         env:
-          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE_2020 }}
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
         with:
           projectPath: ResponsibleUnity
           customImage: thesbergen/unityci-docfx


### PR DESCRIPTION
Use UNITY_LICENSE without version number. Part of making Depeendabot PRs work. Previous use of 2019 and 2020 was either a misunderstanding, or is just no longer required.