### PR TITLE
Never collapse responders in state strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and thus not under semantic versioning.
 ### Added
 - Added support for Unity 2022
 
+### Changed
+- Never collapse responders in state strings (even when completed or not executed).
+  More info is better here. 
+
 ### Fixed
 - Fix path trimming (start from "Assets") in failure messages on Windows
 - Internal tests: Fix some tests that didn't work properly depending on platform and/or locale

--- a/com.beatwaves.responsible/Runtime/State/StateStringBuilder.cs
+++ b/com.beatwaves.responsible/Runtime/State/StateStringBuilder.cs
@@ -167,25 +167,18 @@ namespace Responsible.State
 		{
 			var status = primaryState.Status;
 			var statusLine = status.MakeStatusLine(description);
-			if (status is TestOperationStatus.Completed ||
-				status is TestOperationStatus.NotExecuted)
-			{
-				this.Add(statusLine);
-			}
-			else
-			{
-				this.AddIndented(statusLine, b => b
-					.AddOptional("WAIT FOR", wait)
-					.AddOptional("THEN RESPOND WITH", instruction));
 
-				// Add primary state failure details, if we didn't have failure details yet
-				var failureIncluded =
-					wait.Status is TestOperationStatus.Failed ||
-					instruction?.Status is TestOperationStatus.Failed;
-				if (!failureIncluded)
-				{
-					this.AddFailureDetails(status);
-				}
+			this.AddIndented(statusLine, b => b
+				.AddOptional("WAIT FOR", wait)
+				.AddOptional("THEN RESPOND WITH", instruction));
+
+			// Add primary state failure details, if we didn't have failure details yet
+			var failureIncluded =
+				wait.Status is TestOperationStatus.Failed ||
+				instruction?.Status is TestOperationStatus.Failed;
+			if (!failureIncluded)
+			{
+				this.AddFailureDetails(status);
 			}
 		}
 

--- a/src/Responsible.Tests/SelectFromResponderTests.cs
+++ b/src/Responsible.Tests/SelectFromResponderTests.cs
@@ -70,8 +70,7 @@ namespace Responsible.Tests
 
 			StateAssert.StringContainsInOrder(error.Message)
 				.Failed("SELECT")
-				.FailureDetails()
-				.Nowhere(ConditionResponder.WaitForCompletionDescription);
+				.FailureDetails();
 		}
 
 		[Test]

--- a/src/Responsible.Tests/Utilities/AssertStateString.cs
+++ b/src/Responsible.Tests/Utilities/AssertStateString.cs
@@ -40,12 +40,6 @@ namespace Responsible.Tests.Utilities
 		// An empty line requires whitespace to work nicely with Unity
 		public AssertStateString EmptyLine() => this.DetailsRegex(@"\n\s+\n");
 
-		public AssertStateString Nowhere(string details)
-		{
-			Assert.That(this.str, Does.Not.Contain(details));
-			return this;
-		}
-
 		public AssertStateString Details(string details)
 		{
 			var index = this.str.Substring(this.currentIndex).IndexOf(details, StringComparison.Ordinal);


### PR DESCRIPTION
They used to be collapsed when not executed or completed, but I've come to think that more information is better here.