### PR TITLE
Also bump C# and framework version in .csproj files

### DIFF
--- a/.github/workflows/releasables.yml
+++ b/.github/workflows/releasables.yml
@@ -48,7 +48,7 @@ jobs:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
         with:
           projectPath: ResponsibleUnity
-          customImage: thesbergen/unityci-docfx
+          customImage: thesbergen/unityci-docfx:2022
           targetPlatform: StandaloneLinux64
           buildMethod: Responsible.EditorSetup.ContinuousIntegration.BuildDocumentation
           customParameters: -disable-assembly-updater

--- a/com.beatwaves.responsible/Runtime/Responsible.csproj
+++ b/com.beatwaves.responsible/Runtime/Responsible.csproj
@@ -1,7 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
+        <LangVersion>9</LangVersion>
         <PackageId>Beatwaves.Responsible</PackageId>
         <Version>4.4.0</Version>
         <Authors>Sakari Bergen</Authors>

--- a/com.beatwaves.responsible/Runtime/Responsible.csproj
+++ b/com.beatwaves.responsible/Runtime/Responsible.csproj
@@ -26,7 +26,7 @@
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>

--- a/com.beatwaves.responsible/Runtime/State/Continuation.cs
+++ b/com.beatwaves.responsible/Runtime/State/Continuation.cs
@@ -14,7 +14,7 @@ namespace Responsible.State
 		[CanBeNull] private ITestOperationState<TSecond> executionState;
 
 		public ContinuationState State => this.executionState != null
-			? (ContinuationState)new ContinuationState.Available(this.executionState)
+			? new ContinuationState.Available(this.executionState)
 			: new ContinuationState.NotAvailable(this.creationStatus);
 
 		public Continuation(Func<TFirst, ITestOperationState<TSecond>> makeContinuation)

--- a/docfx/Dockerfile
+++ b/docfx/Dockerfile
@@ -1,4 +1,4 @@
-FROM unityci/editor:ubuntu-2019.4.14f1-linux-il2cpp-0.10.0 as builder
+FROM unityci/editor:ubuntu-2022.3.29f1-base-3 as builder
 RUN apt-get -q update \
     && apt-get -q install -y --no-install-recommends --allow-downgrades \
     unzip
@@ -7,7 +7,7 @@ RUN mkdir -p /docfx \
     && unzip /docfx/docfx.zip -d /docfx/ \
     && rm /docfx/docfx.zip
 
-FROM unityci/editor:ubuntu-2019.4.14f1-linux-il2cpp-0.10.0
+FROM unityci/editor:ubuntu-2022.3.29f1-base-3
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get -q update \
     && apt-get install -y --no-install-recommends gnupg ca-certificates \

--- a/src/Responsible.Tests/Responsible.Tests.csproj
+++ b/src/Responsible.Tests/Responsible.Tests.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>7.3</LangVersion>
+        <TargetFramework>net8.0</TargetFramework>
+        <LangVersion>9</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Responsible.Tests/Responsible.Tests.csproj
+++ b/src/Responsible.Tests/Responsible.Tests.csproj
@@ -11,15 +11,15 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <PackageReference Include="coverlet.collector" Version="6.0.2">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="JetBrains.Annotations" Version="2021.3.0" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-      <PackageReference Include="NSubstitute" Version="4.3.0" />
-      <PackageReference Include="NUnit" Version="3.13.3" />
-      <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+      <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+      <PackageReference Include="NSubstitute" Version="5.1.0" />
+      <PackageReference Include="NUnit" Version="3.14.0" />
+      <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/ResponsibleGherkin.Tests/CodeGeneratorSnapshotTests.cs
+++ b/src/ResponsibleGherkin.Tests/CodeGeneratorSnapshotTests.cs
@@ -1,6 +1,5 @@
 using System.Threading.Tasks;
 using ResponsibleGherkin.Generators;
-using VerifyXunit;
 using Xunit;
 using static VerifyXunit.Verifier;
 using static ResponsibleGherkin.Tests.TestData;

--- a/src/ResponsibleGherkin.Tests/CodeGeneratorSnapshotTests.cs
+++ b/src/ResponsibleGherkin.Tests/CodeGeneratorSnapshotTests.cs
@@ -7,7 +7,6 @@ using static ResponsibleGherkin.Tests.TestData;
 
 namespace ResponsibleGherkin.Tests;
 
-[UsesVerify]
 public class CodeGeneratorSnapshotTests
 {
 	[Theory]

--- a/src/ResponsibleGherkin.Tests/CommentParserTests.cs
+++ b/src/ResponsibleGherkin.Tests/CommentParserTests.cs
@@ -26,11 +26,13 @@ public class CommentParserTests
 	}
 
 
-	[Fact]
-	public void Parse_ThrowsError_WhenDuplicateValue()
+	[Theory]
+	[InlineData("# responsible-flavor: xunit", "# responsible-flavor: NUnit")]
+	[InlineData("# responsible-base-class: C1", "# responsible-base-class: C1")]
+	[InlineData("# responsible-executor: E1", "# responsible-executor: E2")]
+	public void Parse_ThrowsError_WhenDuplicateValue(
+		string comment1, string comment2)
 	{
-		const string comment1 = "# responsible-flavor: xunit";
-		const string comment2 = "# responsible-flavor: NUnit";
 		var parse = () => ParseLines(comment1, comment2);
 		parse.Should()
 			.Throw<InvalidConfigurationException>()

--- a/src/ResponsibleGherkin.Tests/ProgramTests.cs
+++ b/src/ResponsibleGherkin.Tests/ProgramTests.cs
@@ -10,7 +10,6 @@ using static VerifyXunit.Verifier;
 
 namespace ResponsibleGherkin.Tests;
 
-[UsesVerify]
 public class ProgramTests
 {
 	private readonly MockFileSystem fileSystem = new();

--- a/src/ResponsibleGherkin.Tests/ProgramTests.cs
+++ b/src/ResponsibleGherkin.Tests/ProgramTests.cs
@@ -4,7 +4,6 @@ using System.IO.Abstractions.TestingHelpers;
 using System.Threading.Tasks;
 using FluentAssertions;
 using ResponsibleGherkin.Generators;
-using VerifyXunit;
 using Xunit;
 using static VerifyXunit.Verifier;
 

--- a/src/ResponsibleGherkin.Tests/ResponsibleGherkin.Tests.csproj
+++ b/src/ResponsibleGherkin.Tests/ResponsibleGherkin.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
 
         <IsPackable>false</IsPackable>

--- a/src/ResponsibleGherkin.Tests/ResponsibleGherkin.Tests.csproj
+++ b/src/ResponsibleGherkin.Tests/ResponsibleGherkin.Tests.csproj
@@ -8,15 +8,21 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-        <PackageReference Include="coverlet.collector" Version="3.1.0" />
-        <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="16.1.25" />
-        <PackageReference Include="Verify.Xunit" Version="16.5.4" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.analyzers" Version="0.10.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="FluentAssertions" Version="6.12.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+        <PackageReference Include="coverlet.collector" Version="6.0.2">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="21.0.2" />
+        <PackageReference Include="Verify.Xunit" Version="24.2.0" />
+        <PackageReference Include="xunit" Version="2.8.1" />
+        <PackageReference Include="xunit.analyzers" Version="1.14.0">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/ResponsibleGherkin/ResponsibleGherkin.csproj
+++ b/src/ResponsibleGherkin/ResponsibleGherkin.csproj
@@ -19,15 +19,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="editorconfig" Version="0.12.2" />
+      <PackageReference Include="editorconfig" Version="0.15.0" />
       <PackageReference Include="Gherkin" Version="23.0.1" />
-      <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0" />
-      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+      <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
+      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
       <PackageReference Include="System.CommandLine" Version="2.0.0-beta3.22114.1" />
-      <PackageReference Include="System.IO.Abstractions" Version="16.1.25" />
+      <PackageReference Include="System.IO.Abstractions" Version="21.0.2" />
     </ItemGroup>
 
 </Project>

--- a/src/ResponsibleGherkin/ResponsibleGherkin.csproj
+++ b/src/ResponsibleGherkin/ResponsibleGherkin.csproj
@@ -4,7 +4,7 @@
         <OutputType>Exe</OutputType>
         <PackAsTool>true</PackAsTool>
         <ToolCommandName>responsible-gherkin</ToolCommandName>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <PackageId>Beatwaves.ResponsibleGherkin</PackageId>


### PR DESCRIPTION
* Bump .NET 6 projects to .NET 8
* Bump C# language version to 9 (supported by Unity 2021)
* Update (most) NuGet packages, especially `coverlet.collector`. NUnit was not updated to 4 because `ClassicAssert` changes.
* Bump docfx image to use Unity 2022, as some C# 9 changes broke the documentation build (the Dockerfile could use some more love separately)