### PR TITLE
Update to latest docfx version, run with dotnet instead of mono

### DIFF
--- a/.github/workflows/releasables.yml
+++ b/.github/workflows/releasables.yml
@@ -48,7 +48,7 @@ jobs:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
         with:
           projectPath: ResponsibleUnity
-          customImage: thesbergen/unityci-docfx:2022
+          customImage: thesbergen/unityci-docfx:2022-dotnet
           targetPlatform: StandaloneLinux64
           buildMethod: Responsible.EditorSetup.ContinuousIntegration.BuildDocumentation
           customParameters: -disable-assembly-updater

--- a/ResponsibleUnity/Assets/EditorSetup/ContinuousIntegration.cs
+++ b/ResponsibleUnity/Assets/EditorSetup/ContinuousIntegration.cs
@@ -59,7 +59,7 @@ namespace Responsible.EditorSetup
 		        (returnCode, stdout) = RunCommand(
 			        workingDir: DocFxDir,
 			        command: "docfx",
-			        Quote(DocFxJsonPath), "--warningsAsErrors", "--force");
+			        Quote(DocFxJsonPath), "--warningsAsErrors");
 
 		        if (returnCode != 0)
 		        {

--- a/docfx/Dockerfile
+++ b/docfx/Dockerfile
@@ -1,23 +1,6 @@
-FROM unityci/editor:ubuntu-2022.3.29f1-base-3 as builder
-RUN apt-get -q update \
-    && apt-get -q install -y --no-install-recommends --allow-downgrades \
-    unzip
-RUN mkdir -p /docfx \
-    && curl https://github.com/dotnet/docfx/releases/download/v2.56.7/docfx.zip -L --output /docfx/docfx.zip \
-    && unzip /docfx/docfx.zip -d /docfx/ \
-    && rm /docfx/docfx.zip
-
 FROM unityci/editor:ubuntu-2022.3.29f1-base-3
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get -q update \
-    && apt-get install -y --no-install-recommends gnupg ca-certificates \
-    && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
-    && echo "deb https://download.mono-project.com/repo/ubuntu stable-bionic main" | tee /etc/apt/sources.list.d/mono-official-stable.list \
-    && apt-get -q update \
     && apt-get -q install -y --no-install-recommends --allow-downgrades \
-    mono-runtime \
-    mono-devel \
-    msbuild
-COPY --from=builder /docfx /docfx
-RUN printf '#!/bin/bash\nmono /docfx/docfx.exe $@' > /usr/local/bin/docfx \
-    && chmod a+x /usr/local/bin/docfx
+    dotnet-sdk-8.0
+RUN dotnet tool install docfx --version 2.76.0 --tool-path /bin


### PR DESCRIPTION
The Docker image is larger, but the old version also felt really obsolete...