### PR TITLE
Add WaitForPredicate, Obsolete WaitForConditionOn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Experimental features are also **not** under semantic versioning.
 
 ## [Unreleased]
 
+### Added
+- `WaitForPredicate`, which takes the latest polled state value as an argument to the extra context builder.
+
+### Deprecated
+- `WaitForConditionOn` was deprecated in favor or `WaitForPredicate`.
+
 ## [4.5.0] - 2024-05-25
 
 ### Added

--- a/com.beatwaves.responsible/Runtime/Docs/Inherit.cs
+++ b/com.beatwaves.responsible/Runtime/Docs/Inherit.cs
@@ -101,6 +101,19 @@ namespace Responsible.Docs
 		{
 		}
 
+		/// <inheritdoc cref="CallerMember{T1, T2, T3, T4}"/>
+		/// <param name="description">Description of the operation, to be included in the state output.</param>
+		public void CallerMemberWithDescription<T1, T2, T3>(
+			string description,
+			T1 arg1,
+			T1 arg2,
+			T1 arg3,
+			string memberName = "",
+			string sourceFilePath = "",
+			int sourceLineNumber = 0)
+		{
+		}
+
 		/// <inheritdoc cref="CallerMember{T1, T2, T3}"/>
 		/// <param name="description">Description of the operation, to be included in the state output.</param>
 		/// <param name="extraContext">Action for producing extra context into state descriptions.</param>

--- a/com.beatwaves.responsible/Runtime/Docs/Inherit.cs
+++ b/com.beatwaves.responsible/Runtime/Docs/Inherit.cs
@@ -106,8 +106,8 @@ namespace Responsible.Docs
 		public void CallerMemberWithDescription<T1, T2, T3>(
 			string description,
 			T1 arg1,
-			T1 arg2,
-			T1 arg3,
+			T2 arg2,
+			T3 arg3,
 			string memberName = "",
 			string sourceFilePath = "",
 			int sourceLineNumber = 0)

--- a/com.beatwaves.responsible/Runtime/Utilities/ActionExtensions.cs
+++ b/com.beatwaves.responsible/Runtime/Utilities/ActionExtensions.cs
@@ -1,9 +1,17 @@
 using System;
+using JetBrains.Annotations;
+using Responsible.State;
 
 namespace Responsible.Utilities
 {
 	internal static class ActionExtensions
 	{
+		[CanBeNull]
+		public static Action<StateStringBuilder, TState> DiscardingState<TState>(
+			[CanBeNull] this Action<StateStringBuilder> extraContext) => extraContext != null
+			? (builder, _) => extraContext(builder)
+			: null;
+
 		public static Func<object> ReturnUnit<T>(this Action<T> action, T arg) => () =>
 		{
 			action(arg);

--- a/src/Responsible.Tests/BoxResultTests.cs
+++ b/src/Responsible.Tests/BoxResultTests.cs
@@ -18,7 +18,7 @@ namespace Responsible.Tests
 		[OneTimeSetUp]
 		public void OneTimeSetUp()
 		{
-			this.waitForComplete = WaitForConditionOn("Wait", () => this.complete, val => val);
+			this.waitForComplete = WaitForPredicate("Wait", () => this.complete, val => val);
 			this.returnTrue = DoAndReturn("Set completed", () => true);
 			this.throwError = DoAndReturn<int>("Throw error", () => throw new Exception(""));
 		}

--- a/src/Responsible.Tests/ResponsibleTestBase.cs
+++ b/src/Responsible.Tests/ResponsibleTestBase.cs
@@ -10,10 +10,10 @@ namespace Responsible.Tests
 	public class ResponsibleTestBase
 	{
 		protected static readonly ITestWaitCondition<bool> ImmediateTrue =
-			WaitForConditionOn("True", () => true, val => val);
+			WaitForPredicate("True", () => true, val => val);
 
 		protected static readonly ITestWaitCondition<bool> Never =
-			WaitForConditionOn("Never", () => false, _ => false);
+			WaitForPredicate("Never", () => false, _ => false);
 
 		protected static readonly TimeSpan OneSecond = TimeSpan.FromSeconds(1);
 		protected static readonly TimeSpan OneFrame = TimeSpan.FromSeconds(1.0 / 60);

--- a/src/Responsible.Tests/RunAsLoopTests.cs
+++ b/src/Responsible.Tests/RunAsLoopTests.cs
@@ -36,7 +36,7 @@ namespace Responsible.Tests
 		{
 			var frame = 0;
 			var result = Responsibly
-				.WaitForConditionOn(
+				.WaitForPredicate(
 					"Frame to be 10",
 					() => frame,
 					f => f == 10)

--- a/src/Responsible.Tests/WaitForAllOfTests.cs
+++ b/src/Responsible.Tests/WaitForAllOfTests.cs
@@ -20,9 +20,9 @@ namespace Responsible.Tests
 			bool Id(bool val) => val;
 
 			var task = WaitForAllOf(
-					WaitForConditionOn("cond 1", () => fulfilled1, Id),
-					WaitForConditionOn("cond 2", () => fulfilled2, Id),
-					WaitForConditionOn("cond 3", () => fulfilled3, Id))
+					WaitForPredicate("cond 1", () => fulfilled1, Id),
+					WaitForPredicate("cond 2", () => fulfilled2, Id),
+					WaitForPredicate("cond 3", () => fulfilled3, Id))
 				.ExpectWithinSeconds(10)
 				.ToTask(this.Executor);
 

--- a/src/Responsible.Tests/WaitForConditionTests.cs
+++ b/src/Responsible.Tests/WaitForConditionTests.cs
@@ -198,7 +198,7 @@ namespace Responsible.Tests
 				.ExpectWithinSeconds(1)
 				.CreateState();
 
-			var stateString = state.ToString();
+			_ = state.ToString();
 			extraContextRequested.Should().BeFalse();
 		}
 


### PR DESCRIPTION
`WaitForPredicate` passes the last polled state to the context builder. Re-getting the context has always been a nuisance when building extra details.