### PR TITLE
Work around Unity's async cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Experimental features are also **not** under semantic versioning.
 
 ## [Unreleased]
 
+### Changed
+- Breaking change: `RunAs(Simulated)Loop` is now an `async` method.
+  This had to be done to support Unity's async cancellation state to propagate to state strings. 
+
+### Fixed
+- Fix instructions that were canceled because of a failure not showing up as canceled on Unity.
+
 ## [4.5.0] - 2024-05-25
 
 ### Added

--- a/ResponsibleUnity/Assets/UnityTests/ToYieldInstructionTests.cs
+++ b/ResponsibleUnity/Assets/UnityTests/ToYieldInstructionTests.cs
@@ -100,8 +100,9 @@ namespace Responsible.UnityTests
 
 			yield return yieldInstruction;
 
-			// Completes one frame "late", because of Update ordering
-			Assert.AreEqual(this.completedOnFrame + 1, Time.frameCount);
+			// Completes two frames "late", because of Update ordering
+			// and the async cancellation that Unity does
+			Assert.AreEqual(this.completedOnFrame + 2, Time.frameCount);
 
 			object unused;
 			Assert.IsFalse(yieldInstruction.WasCanceled);

--- a/ResponsibleUnity/Assets/UnityTests/WaitForCoroutineTests.cs
+++ b/ResponsibleUnity/Assets/UnityTests/WaitForCoroutineTests.cs
@@ -75,26 +75,28 @@ namespace Responsible.UnityTests
 			}
 		}
 
-		[Test]
-		public void WaitForCoroutine_ContainsCorrectDescription()
+		[UnityTest]
+		public IEnumerator WaitForCoroutine_ContainsCorrectDescription()
 		{
 			var instruction = Responsibly
 				.WaitForCoroutine("Manual", this.ThrowImmediately)
 				.ExpectWithinSeconds(1)
 				.ToYieldInstruction(this.Executor);
 
+			yield return null;
 			Assert.IsTrue(instruction.CompletedWithError);
 			StringAssert.Contains("Manual (Coroutine)", instruction.Error.Message);
 		}
 
-		[Test]
-		public void WaitForCoroutineMethod_ContainsCorrectDescription()
+		[UnityTest]
+		public IEnumerator WaitForCoroutineMethod_ContainsCorrectDescription()
 		{
 			var instruction = Responsibly
 				.WaitForCoroutineMethod(this.ThrowImmediately)
 				.ExpectWithinSeconds(1)
 				.ToYieldInstruction(this.Executor);
 
+			yield return null;
 			Assert.IsTrue(instruction.CompletedWithError);
 			StringAssert.Contains("ThrowImmediately (Coroutine)", instruction.Error.Message);
 		}
@@ -116,8 +118,8 @@ namespace Responsible.UnityTests
 				Does.Match(@"\[✓\] CompleteAfterOneFrame.*\n.*\[!\] ThrowImmediately"));
 		}
 
-		[Test]
-		public void WaitForCoroutine_ThrowsWithInvalidExecutor()
+		[UnityTest]
+		public IEnumerator WaitForCoroutine_ThrowsWithInvalidExecutor()
 		{
 			var nonUnityExecutor = new TestInstructionExecutor(new MockTestScheduler());
 			var instruction = Responsibly
@@ -125,6 +127,7 @@ namespace Responsible.UnityTests
 				.ExpectWithinSeconds(1)
 				.ToYieldInstruction(nonUnityExecutor);
 
+			yield return null;
 			Assert.IsTrue(instruction.CompletedWithError);
 			StringAssert.Contains(nameof(MonoBehaviour), instruction.Error.Message);
 		}

--- a/com.beatwaves.responsible/Runtime/TestInstruction.cs
+++ b/com.beatwaves.responsible/Runtime/TestInstruction.cs
@@ -239,7 +239,7 @@ namespace Responsible
 		/// <typeparam name="T">Return type of the instruction to execute.</typeparam>
 		/// <returns>The result of the test instruction, if it completes successfully.</returns>
 		/// <inheritdoc cref="Docs.Inherit.CallerMember{T1,T2,T3,T4}"/>
-		public static T RunAsSimulatedUpdateLoop<T>(
+		public static Task<T> RunAsSimulatedUpdateLoop<T>(
 			this ITestInstruction<T> instruction,
 			double framesPerSecond,
 			Action<TimeSpan> tick,
@@ -269,7 +269,7 @@ namespace Responsible
 		/// <typeparam name="T">Return type of the instruction to execute.</typeparam>
 		/// <returns>The result of the test instruction, if it completes successfully.</returns>
 		/// <inheritdoc cref="Docs.Inherit.CallerMember{T1,T2,T3}"/>
-		public static T RunAsLoop<T>(
+		public static Task<T> RunAsLoop<T>(
 			this ITestInstruction<T> instruction,
 			Action tick,
 			CancellationToken cancellationToken = default,
@@ -282,7 +282,7 @@ namespace Responsible
 				new GenericRunLoopScheduler(),
 				new SourceContext(nameof(RunAsLoop), memberName, sourceFilePath, sourceLineNumber));
 
-		private static T RunAsLoop<T, TTickArgument>(
+		private static async Task<T> RunAsLoop<T, TTickArgument>(
 			this ITestInstruction<T> instruction,
 			Action<TTickArgument> tick,
 			CancellationToken cancellationToken,
@@ -292,13 +292,14 @@ namespace Responsible
 			using (var executor = new TestInstructionExecutor(scheduler, scheduler.ExternalResultSource))
 			{
 				var task = executor.RunInstruction(instruction.CreateState(), sourceContext, cancellationToken);
-
-				while (!task.IsCompleted)
+				var cts = new CancellationTokenSource();
+				while (!task.IsFaulted && !task.IsCompleted && !cts.Token.IsCancellationRequested)
 				{
-					scheduler.Run(tick);
+					scheduler.Run(tick, cts);
+					await Task.Yield(); // Let the test instruction execution process errors
 				}
 
-				return task.GetAwaiter().GetResult();
+				return await task;
 			}
 		}
 	}

--- a/com.beatwaves.responsible/Runtime/TestInstruction.cs
+++ b/com.beatwaves.responsible/Runtime/TestInstruction.cs
@@ -296,6 +296,9 @@ namespace Responsible
 				while (!task.IsFaulted && !task.IsCompleted && !cts.Token.IsCancellationRequested)
 				{
 					scheduler.Run(tick, cts);
+
+					// This only affects Unity, so no .NET test will catch the mutation
+					// Stryker disable once statement
 					await Task.Yield(); // Let the test instruction execution process errors
 				}
 

--- a/com.beatwaves.responsible/Runtime/TestInstructionExecutor.cs
+++ b/com.beatwaves.responsible/Runtime/TestInstructionExecutor.cs
@@ -140,6 +140,8 @@ namespace Responsible
 						throw;
 					}
 
+					// This only affects Unity, so no .NET test will catch the mutation
+					// Stryker disable once statement
 					await Task.Yield();
 
 					var message = e is TimeoutException

--- a/com.beatwaves.responsible/Runtime/TestInstructionExecutor.cs
+++ b/com.beatwaves.responsible/Runtime/TestInstructionExecutor.cs
@@ -140,6 +140,8 @@ namespace Responsible
 						throw;
 					}
 
+					await Task.Yield();
+
 					var message = e is TimeoutException
 						? this.MakeTimeoutMessage(rootState)
 						: this.MakeErrorMessage(rootState, e);

--- a/com.beatwaves.responsible/Runtime/Utilities/RunLoopScheduler.cs
+++ b/com.beatwaves.responsible/Runtime/Utilities/RunLoopScheduler.cs
@@ -12,7 +12,7 @@ namespace Responsible.Utilities
 
 		public IExternalResultSource ExternalResultSource => this.runLoopExceptionSource;
 
-		public void Run(Action<TTickArgument> tick)
+		public void Run(Action<TTickArgument> tick, CancellationTokenSource cts)
 		{
 			try
 			{
@@ -22,6 +22,7 @@ namespace Responsible.Utilities
 			}
 			catch (Exception e)
 			{
+				cts.Cancel();
 				this.runLoopExceptionSource.SetException(e);
 			}
 		}

--- a/com.beatwaves.responsible/Runtime/Utilities/RunLoopScheduler.cs
+++ b/com.beatwaves.responsible/Runtime/Utilities/RunLoopScheduler.cs
@@ -22,6 +22,8 @@ namespace Responsible.Utilities
 			}
 			catch (Exception e)
 			{
+				// This only affects Unity, so no .NET test will catch the mutation
+				// Stryker disable once statement
 				cts.Cancel();
 				this.runLoopExceptionSource.SetException(e);
 			}

--- a/src/Responsible.Tests/OperationStateTests.cs
+++ b/src/Responsible.Tests/OperationStateTests.cs
@@ -36,7 +36,7 @@ namespace Responsible.Tests
 			StateAssert.StringContainsInOrder(exception.Message)
 				.Failed("EXPECT WITHIN")
 				.Completed(description)
-				.JustCanceled(description);
+				.Canceled(description);
 		}
 
 	}

--- a/src/Responsible.Tests/ResponderTests.cs
+++ b/src/Responsible.Tests/ResponderTests.cs
@@ -109,7 +109,7 @@ namespace Responsible.Tests
 			StateAssert.StringContainsInOrder(message)
 				.Failed("Response CONDITION EXPECTED WITHIN")
 				.Details("WAIT FOR")
-				.JustCanceled("Condition")
+				.Canceled("Condition")
 				.Details("THEN RESPOND WITH ...");
 		}
 	}

--- a/src/Responsible.Tests/StateNotificationsTests.cs
+++ b/src/Responsible.Tests/StateNotificationsTests.cs
@@ -56,10 +56,17 @@ namespace Responsible.Tests
 		}
 
 		[Test]
-		public void StateNotifications_PublishesFinished_WhenOperationFailed()
+		public async Task StateNotifications_PublishesFinished_WhenOperationFailed()
 		{
-			Do("Throw error", () => throw new Exception())
-				.ToTask(this.Executor);
+			try
+			{
+				await Do("Throw error", () => throw new Exception()).ToTask(this.Executor);
+			}
+			catch
+			{
+				// Ignore, it's expected
+			}
+			
 			(this.notification?.type).Should().Be(TestOperationStateTransition.Finished);
 		}
 

--- a/src/Responsible.Tests/Utilities/AssertStateString.cs
+++ b/src/Responsible.Tests/Utilities/AssertStateString.cs
@@ -27,14 +27,6 @@ namespace Responsible.Tests.Utilities
 		public AssertStateString Waiting(string description) => this.DetailsWithMarker('.', description);
 		public AssertStateString Canceled(string description) => this.DetailsWithMarker('-', description);
 
-		// Work around Unity 2021 cancellation happening asynchronously (but within same frame)
-		public AssertStateString JustCanceled(string description) =>
-#if UNITY_2021_3_OR_NEWER // Not sure about the exact version this started happening :/
-			this.Waiting(description);
-#else
-			this.Canceled(description);
-#endif
-
 		public AssertStateString FailureDetails() => this.Details("Failed with:");
 
 		// An empty line requires whitespace to work nicely with Unity


### PR DESCRIPTION
Under certain circumstances, task cancellation in Unity will happen later in the same frame, instead of synchronously.

Due to this, state strings during errors often get updated only after the error has been propagated, causing them to be waiting (`[.]`) instead of canceled (`[-]`). This also caused the tests for Unity to have to be slightly different from .NET tests.

To work around this, we can `await Task.Yield()` before propagating errors.

It caused some breaking changes in `RunAsLoop`, which can no longer be synchronous, so I'm starting a v5 branch now, as there are other breaking changes I'd also like to make.