### PR TITLE
Make interface members + downstream types internal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,10 @@ Experimental features are also **not** under semantic versioning.
 
 ### Changed
 - Breaking change: `RunAs(Simulated)Loop` is now an `async` method.
-  This had to be done to support Unity's async cancellation state to propagate to state strings. 
+  This had to be done to support Unity's async cancellation state to propagate to state strings.
+- Breaking change: Make interface members that were always only intended for internal use internal.
+  This was not possible before C#8, but now that we no longer support older Unity versions,
+  it can be done, allowing more flexibility to change things without breaking things in the future.
 
 ### Fixed
 - Fix instructions that were canceled because of a failure not showing up as canceled on Unity.

--- a/ResponsibleUnity/Assets/EditorTests/FakeOperationState.cs
+++ b/ResponsibleUnity/Assets/EditorTests/FakeOperationState.cs
@@ -18,8 +18,8 @@ namespace Responsible.EditorTests
 			this.Exception = exception;
 		}
 
-		public TestOperationStatus Status => throw new NotImplementedException();
-		public void BuildDescription(StateStringBuilder builder) => throw new NotImplementedException();
+		TestOperationStatus ITestOperationState.Status => throw new NotImplementedException();
+		void ITestOperationState.BuildDescription(StateStringBuilder builder) => throw new NotImplementedException();
 
 		public override string ToString() => this.Exception != null
 			? throw this.Exception

--- a/com.beatwaves.responsible/Runtime/AssemblyInfo.cs
+++ b/com.beatwaves.responsible/Runtime/AssemblyInfo.cs
@@ -1,0 +1,8 @@
+using System.Runtime.CompilerServices;
+
+// Testing the Unity Editor utilities is very tedious without
+// implementing fake operation states.
+// We don't want to test internals in the core tests,
+// but here it's ok, as long as the use is very limited.
+[assembly:InternalsVisibleTo("Responsible.EditorTests")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/com.beatwaves.responsible/Runtime/AssemblyInfo.cs.meta
+++ b/com.beatwaves.responsible/Runtime/AssemblyInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9c07d9f58a5880041b69aa63687e4b23
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.beatwaves.responsible/Runtime/Context/RunContext.cs
+++ b/com.beatwaves.responsible/Runtime/Context/RunContext.cs
@@ -2,9 +2,8 @@ namespace Responsible.Context
 {
 	/// <summary>
 	/// Represents the context in which a test operation is run from.
-	/// Only for internal use.
 	/// </summary>
-	public readonly struct RunContext
+	internal readonly struct RunContext
 	{
 		internal readonly ITestScheduler Scheduler;
 		internal readonly SourceContext SourceContext;

--- a/com.beatwaves.responsible/Runtime/IExternalResultSource.cs
+++ b/com.beatwaves.responsible/Runtime/IExternalResultSource.cs
@@ -22,6 +22,6 @@ namespace Responsible
 		/// </param>
 		/// <typeparam name="T">Type of the test instruction being executed.</typeparam>
 		/// <returns>A task which will cause early failure or completion of the executed test instruction.</returns>
-		Task<T> GetExternalResult<T>(CancellationToken cancellationToken);
+		public Task<T> GetExternalResult<T>(CancellationToken cancellationToken);
 	}
 }

--- a/com.beatwaves.responsible/Runtime/IFailureListener.cs
+++ b/com.beatwaves.responsible/Runtime/IFailureListener.cs
@@ -14,6 +14,6 @@ namespace Responsible
 		/// <param name="failureMessage">
 		/// Message detailing the failure, including the state of the operation.
 		/// </param>
-		void OperationFailed(Exception exception, string failureMessage);
+		public void OperationFailed(Exception exception, string failureMessage);
 	}
 }

--- a/com.beatwaves.responsible/Runtime/IGlobalContextProvider.cs
+++ b/com.beatwaves.responsible/Runtime/IGlobalContextProvider.cs
@@ -11,6 +11,6 @@ namespace Responsible
 		/// Add any details that might be useful as global context to include when test operations fail.
 		/// </summary>
 		/// <param name="contextBuilder">The string builder to use to build the context.</param>
-		void BuildGlobalContext(StateStringBuilder contextBuilder);
+		public void BuildGlobalContext(StateStringBuilder contextBuilder);
 	}
 }

--- a/com.beatwaves.responsible/Runtime/ITestOperation.cs
+++ b/com.beatwaves.responsible/Runtime/ITestOperation.cs
@@ -34,6 +34,6 @@ namespace Responsible
 		/// </remarks>
 		[Pure]
 		[NotNull]
-		ITestOperationState<T> CreateState();
+		public ITestOperationState<T> CreateState();
 	}
 }

--- a/com.beatwaves.responsible/Runtime/ITestScheduler.cs
+++ b/com.beatwaves.responsible/Runtime/ITestScheduler.cs
@@ -15,7 +15,7 @@ namespace Responsible
 		/// Used for waiting for frames, and for providing state details for operations.
 		/// </summary>
 		/// <value>Current frame value.</value>
-		int FrameNow { get; }
+		public int FrameNow { get; }
 
 		/// <summary>
 		/// Returns the current time.
@@ -26,7 +26,7 @@ namespace Responsible
 		/// <remarks>
 		/// This exists mostly so that it can be mocked in internal Responsible tests.
 		/// </remarks>
-		DateTimeOffset TimeNow { get; }
+		public DateTimeOffset TimeNow { get; }
 
 		/// <summary>
 		/// Registers a poll callback to be called at least once per frame.
@@ -35,6 +35,6 @@ namespace Responsible
 		/// </summary>
 		/// <param name="action">Action to call at least once on every frame.</param>
 		/// <returns>A disposable instance, which must unregister the callback when disposed.</returns>
-		IDisposable RegisterPollCallback(Action action);
+		public IDisposable RegisterPollCallback(Action action);
 	}
 }

--- a/com.beatwaves.responsible/Runtime/State/BoxedOperationState.cs
+++ b/com.beatwaves.responsible/Runtime/State/BoxedOperationState.cs
@@ -26,7 +26,7 @@ namespace Responsible.State
 			return this.boxingSelector(result);
 		}
 
-		public override void BuildDescription(StateStringBuilder builder) => this.state.BuildDescription(builder);
+		protected override void BuildDescription(StateStringBuilder builder) => this.state.BuildDescription(builder);
 	}
 
 	internal class BoxedOperationState<T> : BoxedOperationState<T, object>

--- a/com.beatwaves.responsible/Runtime/State/ITestOperationState.cs
+++ b/com.beatwaves.responsible/Runtime/State/ITestOperationState.cs
@@ -11,16 +11,16 @@ namespace Responsible.State
 	public interface ITestOperationState
 	{
 		/// <summary>
-		/// Current status of the test operation. Intended for internal use only.
+		/// Current status of the test operation.
 		/// </summary>
 		/// <value>The current state of this test operation run.</value>
-		TestOperationStatus Status { get; }
+		internal TestOperationStatus Status { get; }
 
 		/// <summary>
 		/// Adds a detailed description of the operation to the builder.
 		/// </summary>
 		/// <param name="builder">State string builder to append the description of this operation state to.</param>
-		void BuildDescription(StateStringBuilder builder);
+		internal void BuildDescription(StateStringBuilder builder);
 	}
 
 	/// <summary>
@@ -40,8 +40,6 @@ namespace Responsible.State
 	{
 		/// <summary>
 		/// Starts execution of the the operation this state was created from.
-		///
-		/// Intended for internal use only.
 		/// </summary>
 		/// <param name="runContext">The test operation run context this run is part of.</param>
 		/// <param name="cancellationToken">Cancellation token for canceling the run.</param>
@@ -53,7 +51,7 @@ namespace Responsible.State
 		/// we have to use this unsafe method. However, it is used only from an extension method,
 		/// which does the correct type inference for us, so overall, things are safe.
 		/// </remarks>
-		Task<TResult> ExecuteUnsafe<TResult>(RunContext runContext, CancellationToken cancellationToken);
+		internal Task<TResult> ExecuteUnsafe<TResult>(RunContext runContext, CancellationToken cancellationToken);
 			// where T : TResult <-- not supported in C#
 	}
 }

--- a/com.beatwaves.responsible/Runtime/State/SelectOperationState.cs
+++ b/com.beatwaves.responsible/Runtime/State/SelectOperationState.cs
@@ -35,7 +35,7 @@ namespace Responsible.State
 			return await this.selectState.Execute(runContext, cancellationToken);
 		}
 
-		public override void BuildDescription(StateStringBuilder builder) =>
+		protected override void BuildDescription(StateStringBuilder builder) =>
 			builder.AddSelect<T1, T2>(this.first, this.SelectStatus);
 	}
 }

--- a/com.beatwaves.responsible/Runtime/State/TestOperationStatus.cs
+++ b/com.beatwaves.responsible/Runtime/State/TestOperationStatus.cs
@@ -12,10 +12,8 @@ namespace Responsible.State
 	/// * Completed
 	/// * Failed
 	/// * Canceled
-	///
-	/// Not intended for public use.
 	/// </summary>
-	public abstract class TestOperationStatus
+	internal abstract class TestOperationStatus
 	{
 		internal abstract string MakeStatusLine(string description);
 

--- a/com.beatwaves.responsible/Runtime/State/UntilResponderState.cs
+++ b/com.beatwaves.responsible/Runtime/State/UntilResponderState.cs
@@ -52,7 +52,7 @@ namespace Responsible.State
 			}
 		}
 
-		public override void BuildDescription(StateStringBuilder builder) =>
+		protected override void BuildDescription(StateStringBuilder builder) =>
 			builder.AddUntilResponder(
 				"RESPOND TO",
 				this.respondTo,

--- a/com.beatwaves.responsible/Runtime/TestInstructions/ContinuationTestInstruction.cs
+++ b/com.beatwaves.responsible/Runtime/TestInstructions/ContinuationTestInstruction.cs
@@ -37,7 +37,7 @@ namespace Responsible.TestInstructions
 				return await this.continuation.Execute(firstResult, runContext, cancellationToken);
 			}
 
-			public override void BuildDescription(StateStringBuilder builder) =>
+			protected override void BuildDescription(StateStringBuilder builder) =>
 				builder.AddContinuation(this.first, this.continuation.State);
 		}
 	}

--- a/com.beatwaves.responsible/Runtime/TestInstructions/ExpectConditionInstruction.cs
+++ b/com.beatwaves.responsible/Runtime/TestInstructions/ExpectConditionInstruction.cs
@@ -35,7 +35,7 @@ namespace Responsible.TestInstructions
 					cancellationToken,
 					ct => this.condition.Execute(runContext, ct));
 
-			public override void BuildDescription(StateStringBuilder builder) =>
+			protected override void BuildDescription(StateStringBuilder builder) =>
 				builder.AddExpectWithin(this, this.timeout, this.condition);
 		}
 	}

--- a/com.beatwaves.responsible/Runtime/TestInstructions/ExpectTestResponse.cs
+++ b/com.beatwaves.responsible/Runtime/TestInstructions/ExpectTestResponse.cs
@@ -38,7 +38,7 @@ namespace Responsible.TestInstructions
 				return await instruction.Execute(runContext, cancellationToken);
 			}
 
-			public override void BuildDescription(StateStringBuilder builder) =>
+			protected override void BuildDescription(StateStringBuilder builder) =>
 				builder.AddExpectWithin(this, this.timeout, this.responder);
 		}
 	}

--- a/com.beatwaves.responsible/Runtime/TestInstructions/GroupedAsInstruction.cs
+++ b/com.beatwaves.responsible/Runtime/TestInstructions/GroupedAsInstruction.cs
@@ -31,7 +31,7 @@ namespace Responsible.TestInstructions
 			protected override Task<T> ExecuteInner(RunContext runContext, CancellationToken cancellationToken) =>
 				this.state.Execute(runContext, cancellationToken);
 
-			public override void BuildDescription(StateStringBuilder builder) =>
+			protected override void BuildDescription(StateStringBuilder builder) =>
 				builder.AddParentWithChildren(this.description, this, new[] { this.state });
 		}
 	}

--- a/com.beatwaves.responsible/Runtime/TestInstructions/SequencedTestInstruction.cs
+++ b/com.beatwaves.responsible/Runtime/TestInstructions/SequencedTestInstruction.cs
@@ -38,7 +38,7 @@ namespace Responsible.TestInstructions
 				return await this.second.Execute(runContext, cancellationToken);
 			}
 
-			public override void BuildDescription(StateStringBuilder builder) =>
+			protected override void BuildDescription(StateStringBuilder builder) =>
 				builder.AddContinuation(this.first, new ContinuationState.Available(this.second));
 		}
 	}

--- a/com.beatwaves.responsible/Runtime/TestInstructions/SynchronousTestInstruction.cs
+++ b/com.beatwaves.responsible/Runtime/TestInstructions/SynchronousTestInstruction.cs
@@ -28,7 +28,7 @@ namespace Responsible.TestInstructions
 			protected override Task<T> ExecuteInner(RunContext runContext, CancellationToken cancellationToken)
 				=> Task.FromResult(this.action());
 
-			public override void BuildDescription(StateStringBuilder builder) =>
+			protected override void BuildDescription(StateStringBuilder builder) =>
 				builder.AddInstruction(this, this.description);
 		}
 	}

--- a/com.beatwaves.responsible/Runtime/TestInstructions/WaitForFramesInstruction.cs
+++ b/com.beatwaves.responsible/Runtime/TestInstructions/WaitForFramesInstruction.cs
@@ -33,7 +33,7 @@ namespace Responsible.TestInstructions
 					cancellationToken);
 			}
 
-			public override void BuildDescription(StateStringBuilder builder) =>
+			protected override void BuildDescription(StateStringBuilder builder) =>
 				builder.AddInstruction(this, $"WAIT FOR {this.wholeFramesToWaitFor} FRAME(S)");
 		}
 	}

--- a/com.beatwaves.responsible/Runtime/TestInstructions/WaitForInstruction.cs
+++ b/com.beatwaves.responsible/Runtime/TestInstructions/WaitForInstruction.cs
@@ -35,7 +35,7 @@ namespace Responsible.TestInstructions
 					cancellationToken);
 			}
 
-			public override void BuildDescription(StateStringBuilder builder) =>
+			protected override void BuildDescription(StateStringBuilder builder) =>
 				builder.AddInstruction(this, $"WAIT FOR {this.waitTime:g}");
 		}
 	}

--- a/com.beatwaves.responsible/Runtime/TestResponders/AnyOfResponder.cs
+++ b/com.beatwaves.responsible/Runtime/TestResponders/AnyOfResponder.cs
@@ -36,7 +36,7 @@ namespace Responsible.TestResponders
 				return Task.FromResult(MultipleTaskSource.Make(this.responders.Select(MakeLauncher)));
 			}
 
-			public override void BuildDescription(StateStringBuilder builder) =>
+			protected override void BuildDescription(StateStringBuilder builder) =>
 				builder.AddToPreviousLineWithChildren(" ANY OF", this.responders);
 		}
 	}

--- a/com.beatwaves.responsible/Runtime/TestResponders/RepeatedlyResponder.cs
+++ b/com.beatwaves.responsible/Runtime/TestResponders/RepeatedlyResponder.cs
@@ -53,7 +53,7 @@ namespace Responsible.TestResponders
 					}));
 			}
 
-			public override void BuildDescription(StateStringBuilder builder)
+			protected override void BuildDescription(StateStringBuilder builder)
 			{
 				if (!this.states.Any())
 				{

--- a/com.beatwaves.responsible/Runtime/TestResponders/SelectResponder.cs
+++ b/com.beatwaves.responsible/Runtime/TestResponders/SelectResponder.cs
@@ -43,7 +43,7 @@ namespace Responsible.TestResponders
 				return this.selectState;
 			}
 
-			public override void BuildDescription(StateStringBuilder builder) =>
+			protected override void BuildDescription(StateStringBuilder builder) =>
 				builder.AddSelect<T1, T2>(
 					this.responder,
 					this.selectState?.SelectStatus ?? TestOperationStatus.NotExecuted.Instance);

--- a/com.beatwaves.responsible/Runtime/TestResponders/TestResponder.cs
+++ b/com.beatwaves.responsible/Runtime/TestResponders/TestResponder.cs
@@ -48,7 +48,7 @@ namespace Responsible.TestResponders
 				return instruction;
 			}
 
-			public override void BuildDescription(StateStringBuilder builder) => builder.AddResponder(this);
+			protected override void BuildDescription(StateStringBuilder builder) => builder.AddResponder(this);
 		}
 	}
 }

--- a/com.beatwaves.responsible/Runtime/TestWaitConditions/AllOfWaitCondition.cs
+++ b/com.beatwaves.responsible/Runtime/TestWaitConditions/AllOfWaitCondition.cs
@@ -38,7 +38,7 @@ namespace Responsible.TestWaitConditions
 			}
 
 
-			public override void BuildDescription(StateStringBuilder builder) =>
+			protected override void BuildDescription(StateStringBuilder builder) =>
 				builder.AddParentWithChildren(
 					"WAIT FOR ALL OF",
 					this,

--- a/com.beatwaves.responsible/Runtime/TestWaitConditions/ContinuedWaitCondition.cs
+++ b/com.beatwaves.responsible/Runtime/TestWaitConditions/ContinuedWaitCondition.cs
@@ -40,7 +40,7 @@ namespace Responsible.TestWaitConditions
 				return await this.continuation.Execute(firstResult, runContext, cancellationToken);
 			}
 
-			public override void BuildDescription(StateStringBuilder builder) =>
+			protected override void BuildDescription(StateStringBuilder builder) =>
 				builder.AddContinuation(this.first, this.continuation.State);
 		}
 	}

--- a/com.beatwaves.responsible/Runtime/TestWaitConditions/PollingWaitCondition.cs
+++ b/com.beatwaves.responsible/Runtime/TestWaitConditions/PollingWaitCondition.cs
@@ -48,7 +48,7 @@ namespace Responsible.TestWaitConditions
 					this.condition,
 					cancellationToken);
 
-			public override void BuildDescription(StateStringBuilder builder) => builder.AddWait(this);
+			protected override void BuildDescription(StateStringBuilder builder) => builder.AddWait(this);
 		}
 	}
 }

--- a/com.beatwaves.responsible/Runtime/TestWaitConditions/RepeatUntilCondition.cs
+++ b/com.beatwaves.responsible/Runtime/TestWaitConditions/RepeatUntilCondition.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Responsible.Context;
@@ -37,7 +37,7 @@ namespace Responsible.TestWaitConditions
 				this.waitState = condition.CreateState();
 			}
 
-			public override void BuildDescription(StateStringBuilder builder)
+			protected override void BuildDescription(StateStringBuilder builder)
 			{
 				builder.AddNestedDetails("UNTIL", this.waitState.BuildDescription);
 				builder.AddNestedDetails("REPEATEDLY EXECUTING", b =>

--- a/com.beatwaves.responsible/Runtime/TestWaitConditions/RespondToAllOfWaitCondition.cs
+++ b/com.beatwaves.responsible/Runtime/TestWaitConditions/RespondToAllOfWaitCondition.cs
@@ -46,7 +46,7 @@ namespace Responsible.TestWaitConditions
 				return results;
 			}
 
-			public override void BuildDescription(StateStringBuilder builder) =>
+			protected override void BuildDescription(StateStringBuilder builder) =>
 				builder.AddToPreviousLineWithChildren(" ALL OF", this.responders);
 		}
 	}

--- a/com.beatwaves.responsible/Runtime/TestWaitConditions/SequencedWaitCondition.cs
+++ b/com.beatwaves.responsible/Runtime/TestWaitConditions/SequencedWaitCondition.cs
@@ -38,7 +38,7 @@ namespace Responsible.TestWaitConditions
 				return await this.second.Execute(runContext, cancellationToken);
 			}
 
-			public override void BuildDescription(StateStringBuilder builder) =>
+			protected override void BuildDescription(StateStringBuilder builder) =>
 				builder.AddContinuation(this.first, new ContinuationState.Available(this.second));
 		}
 	}

--- a/com.beatwaves.responsible/Runtime/TestWaitConditions/TaskWaitCondition.cs
+++ b/com.beatwaves.responsible/Runtime/TestWaitConditions/TaskWaitCondition.cs
@@ -30,7 +30,7 @@ namespace Responsible.TestWaitConditions
 			protected override Task<T> ExecuteInner(RunContext runContext, CancellationToken cancellationToken)
 				=> this.taskRunner(cancellationToken);
 
-			public override void BuildDescription(StateStringBuilder builder)
+			protected override void BuildDescription(StateStringBuilder builder)
 				=> builder.AddWait(this);
 		}
 	}

--- a/com.beatwaves.responsible/Runtime/Unity/ConstraintWaitCondition.cs
+++ b/com.beatwaves.responsible/Runtime/Unity/ConstraintWaitCondition.cs
@@ -57,7 +57,7 @@ namespace Responsible.Unity
 					obj => this.constraint.ApplyTo(obj).IsSuccess,
 					cancellationToken);
 
-			public override void BuildDescription(StateStringBuilder builder) => builder.AddWait(this);
+			protected override void BuildDescription(StateStringBuilder builder) => builder.AddWait(this);
 
 			private void AddDetails(StateStringBuilder stateBuilder)
 			{

--- a/com.beatwaves.responsible/Runtime/Unity/CoroutineWaitCondition.cs
+++ b/com.beatwaves.responsible/Runtime/Unity/CoroutineWaitCondition.cs
@@ -97,7 +97,7 @@ namespace Responsible.Unity
 				HandleImpossibleConcurrentCancellation(cancellationToken, completionSource);
 			}
 
-			public override void BuildDescription(StateStringBuilder builder) => builder.AddWait(this);
+			protected override void BuildDescription(StateStringBuilder builder) => builder.AddWait(this);
 
 			[ExcludeFromCodeCoverage]
 			private static void HandleImpossibleConcurrentCancellation(

--- a/com.beatwaves.responsible/Runtime/Utilities/IMultipleTaskAwaiter.cs
+++ b/com.beatwaves.responsible/Runtime/Utilities/IMultipleTaskAwaiter.cs
@@ -9,7 +9,7 @@ namespace Responsible.Utilities
 	/// Intended only for internal use, but is public, because it's visible from other interfaces.
 	/// </remarks>
 	/// <typeparam name="T">Type of the tasks that this instance yields.</typeparam>
-	public interface IMultipleTaskAwaiter<T>
+	internal interface IMultipleTaskAwaiter<T>
 	{
 		/// <summary>
 		/// Determines if there are more tasks to await for.

--- a/com.beatwaves.responsible/Runtime/Utilities/IMultipleTaskSource.cs
+++ b/com.beatwaves.responsible/Runtime/Utilities/IMultipleTaskSource.cs
@@ -19,6 +19,6 @@ namespace Responsible.Utilities
 		/// Cancellation token passed to all the tasks started by this source.
 		/// </param>
 		/// <returns>A multiple task awaiter for the deferred tasks in this source.</returns>
-		IMultipleTaskAwaiter<T> Start(CancellationToken cancellationToken);
+		internal IMultipleTaskAwaiter<T> Start(CancellationToken cancellationToken);
 	}
 }

--- a/com.beatwaves.responsible/Runtime/Utilities/MultipleTaskSource.cs
+++ b/com.beatwaves.responsible/Runtime/Utilities/MultipleTaskSource.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;

--- a/com.beatwaves.responsible/Runtime/Utilities/MultipleTaskSource.cs
+++ b/com.beatwaves.responsible/Runtime/Utilities/MultipleTaskSource.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -19,7 +20,7 @@ namespace Responsible.Utilities
 			this.taskFactories = deferredTasks.ToList();
 		}
 
-		public IMultipleTaskAwaiter<T> Start(CancellationToken cancellationToken)
+		IMultipleTaskAwaiter<T> IMultipleTaskSource<T>.Start(CancellationToken cancellationToken)
 			=> MultipleTaskAwaiter.Make(this.taskFactories
 				.Select(factory => factory(cancellationToken)));
 	}

--- a/com.beatwaves.responsible/Runtime/Utilities/RepeatedTaskSource.cs
+++ b/com.beatwaves.responsible/Runtime/Utilities/RepeatedTaskSource.cs
@@ -15,7 +15,7 @@ namespace Responsible.Utilities
 			this.taskFactory = taskFactory;
 		}
 
-		public IMultipleTaskAwaiter<T> Start(CancellationToken cancellationToken)
+		IMultipleTaskAwaiter<T> IMultipleTaskSource<T>.Start(CancellationToken cancellationToken)
 		{
 			return new Awaiter(this.taskFactory, cancellationToken);
 		}


### PR DESCRIPTION
This will allow more flexible non-breaking changes in the future. Made possible by C#8 (and we no longer support older Unity versions).

Resolves #244